### PR TITLE
Fix mirror update logic

### DIFF
--- a/new_dsg_environment/azure-vms/cloud-init-mirror-external-cran.yaml
+++ b/new_dsg_environment/azure-vms/cloud-init-mirror-external-cran.yaml
@@ -44,6 +44,11 @@ write_files:
     content: |
       #! /bin/bash
       rsync -rtlzv --delete --progress cran.r-project.org::CRAN /datadrive/mirrordaemon/www/cran
+  - path: "/home/mirrordaemon/pull_then_push.sh"
+    content: |
+      #! /bin/bash
+      source ~mirrordaemon/pull_from_internet.sh
+      source ~mirrordaemon/push_to_internal_mirrors.sh
 
 runcmd:
   # Generate SSH keys for connecting to the internal mirror
@@ -88,8 +93,7 @@ runcmd:
 
   # Schedule initial update for next boot
   - echo "*** Schedule mirror update jobs for next boot... ***"
-  - echo "@reboot mirrordaemon ~mirrordaemon/pull_from_internet.sh" >> /etc/crontab
-  - echo "@reboot mirrordaemon ~mirrordaemon/push_to_internal_mirrors.sh" >> /etc/crontab
+  - echo "@reboot mirrordaemon ~mirrordaemon/pull_then_push.sh" >> /etc/crontab
 
   # Print out some diagnostic information
   - echo "*** This server is currently aware of internal mirrors at the following locations ***"

--- a/new_dsg_environment/azure-vms/cloud-init-mirror-external-pypi.yaml
+++ b/new_dsg_environment/azure-vms/cloud-init-mirror-external-pypi.yaml
@@ -47,6 +47,11 @@ write_files:
     content: |
       #! /bin/bash
       /bandersnatch/bin/bandersnatch mirror
+  - path: "/home/mirrordaemon/pull_then_push.sh"
+    content: |
+      #! /bin/bash
+      source ~mirrordaemon/pull_from_internet.sh
+      source ~mirrordaemon/push_to_internal_mirrors.sh
   - path: "/etc/bandersnatch.conf"
     content: |
         [mirror]
@@ -145,8 +150,7 @@ runcmd:
 
   # Schedule initial update for next boot
   - echo "*** Scheduling mirror update jobs for next boot... ***"
-  - echo "@reboot mirrordaemon ~mirrordaemon/pull_from_internet.sh" >> /etc/crontab
-  - echo "@reboot mirrordaemon ~mirrordaemon/push_to_internal_mirrors.sh" >> /etc/crontab
+  - echo "@reboot mirrordaemon ~mirrordaemon/pull_then_push.sh" >> /etc/crontab
 
   # Print out some diagnostic information
   - echo "*** This server is currently aware of internal mirrors at the following locations ***"


### PR DESCRIPTION
Update logic surrounding updating mirrors such that the initial push happens *after* the initial pull (rather than simultaneously).

Closes #243.