### PR TITLE
Add Powershell script to peer DSG and mirror VNets

### DIFF
--- a/new_dsg_environment/azure-runbooks/dsg_build_instructions.md
+++ b/new_dsg_environment/azure-runbooks/dsg_build_instructions.md
@@ -909,32 +909,31 @@ To deploy a compute VM you will need the following available on the machine you 
 
 - Run the `./Lockdown_Network.ps1` script, providing the DSG ID when prompted
 
-## 9. Peer DSG and mirror networks
-**NOTE:** At the  moment, package mirrors are suitable for **Tier 2 and below** DSGs only.
+## 9. Peer DSG and package mirror networks
+**WARNING:** At the  moment, package mirrors are suitable for **Tier 2 and below** DSGs only.
 
-Change to the `new_dsg_environment/azure-vms/` folder and open a bash terminal with access to the `Az` CLI and run the `./peer_mirrors_to_compute_vms.sh` script as detailed below.
-
-```
-usage: ./peer_mirrors_to_compute_vms.sh [-h] -s subscription_compute -t subscription_mirror [-g resource_group_compute] [-h resource_group_mirror] [-n vnet_name_compute] [-m vnet_name_mirror]
-  -h                                   display help
-  -s subscription_compute [required]   specify subscription where the compute VNet is deployed. (typically this will be 'Data Study Group Testing')
-  -t subscription_mirror [required]    specify subscription where the mirror VNet is deployed. (typically this will be 'Safe Haven Management Testing')
-  -c resource_group_compute            specify resource group where the compute VNet is deployed (defaults to 'RG_DSG_VNET')
-  -m resource_group_mirror             specify resource group where the mirror VNet is deployed (defaults to 'RG_SH_PKG_MIRRORS')
-  -v vnet_name_compute                 specify name of the compute VNet (defaults to 'DSG_DSGROUPTEST_VNet1')
-  -w vnet_name_mirror                  specify name of the mirror VNet (defaults to 'VNET_SH_PKG_MIRRORS')
-```
+**=== Do not peer Tier 3 or above DSGs to the mirror network ===**
 
 This script peers the DSG virtual network with the mirror virtual network in the management subscription so that the compute VMs can talk to the mirror servers.
+
 Note that the "inbound one-way airlock" for packages is enforced by the NSG rules for the external and internal mirrrors.
+
 The **external** mirror NSG rules do not allow **any inbound** communication, while permitting outbound communication to the internet (for pulling package updates from the public package servers) and its associated internal mirrors (for pushing to these mirror servers).
+
 The **internal** mirror NSG rules do not allow **any outbound** communication, while permitting inbound communication from their associated external mirrors (to receive pushed package updates) and from the DSGs that are peered with them (to serve packages to these DSGs).
 
-Example usage:
+To peer the DSG and package mirror networks:
 
-```bash
-./peer_mirrors_to_compute_vms.sh -s "Data Study Group Testing" "Safe Haven Management Testing"
-```
+- Ensure you have the latest version of the Safe Haven repository from [https://github.com/alan-turing-institute/data-safe-haven](https://github.com/alan-turing-institute/data-safe-haven).
+
+- Change to the `new_dsg_environment/dsg_deploy_scripts/09_peer_mirrors/` directory of the Safe Haven repository
+
+- Ensure you are logged into the Azure within PowerShell using the command: `Connect-AzAccount`
+
+- Ensure the active subscription is set to that you are using for the new DSG environment using the command: `Set-AzContext -SubscriptionId "<dsg-subscription-name>"`
+
+- Run the `./Peer_Dsg_And_Mirror_Networks.ps1` script, providing the DSG ID when prompted
+
 
 ## 10. Run smoke tests on shared compute VM
 These tests should be run **after** the network lock down and peering the DSG and mirror VNets.

--- a/new_dsg_environment/dsg_configs/full/dsg_10_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_10_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_11_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_11_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_12_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_12_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_13_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_13_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_14_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_14_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_15_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_15_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_4_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_4_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": ""
       },

--- a/new_dsg_environment/dsg_configs/full/dsg_9_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_9_full_config.json
@@ -55,6 +55,10 @@
   },
   "dsg": {
     "mirrors": {
+      "vnet": {
+        "rg": "RG_SH_PKG_MIRRORS",
+        "name": "VNET_SH_PKG_MIRRORS"
+      },
       "cran": {
         "ip": "10.1.0.21"
       },

--- a/new_dsg_environment/dsg_deploy_scripts/09_peer_mirrors/Peer_Dsg_And_Mirror_Networks.ps1
+++ b/new_dsg_environment/dsg_deploy_scripts/09_peer_mirrors/Peer_Dsg_And_Mirror_Networks.ps1
@@ -1,0 +1,54 @@
+param(
+  [Parameter(Position=0, Mandatory = $true, HelpMessage = "Enter DSG ID (usually a number e.g enter '9' for DSG9)")]
+  [string]$dsgId
+)
+
+Import-Module Az
+Import-Module $PSScriptRoot/../DsgConfig.psm1 -Force
+
+# Get DSG config
+$config = Get-DsgConfig($dsgId)
+
+# Temporarily switch to DSG subscription
+$prevContext = Get-AzContext
+Set-AzContext -SubscriptionId $config.dsg.subscriptionName;
+
+# Fetch DSG Vnet
+$dsgVnet = Get-AzVirtualNetwork -Name $config.dsg.network.vnet.name `
+                                -ResourceGroupName $config.dsg.network.vnet.rg 
+
+# Temporarily switch to management subscription
+Set-AzContext -SubscriptionId $config.shm.subscriptionName;
+# Fetch Mirrors Vnet
+$mirrorVnet = Get-AzVirtualNetwork -Name $config.dsg.mirrors.vnet.name `
+                                -ResourceGroupName $config.dsg.mirrors.vnet.rg
+# Add Peering to Mirror Vnet
+$mirrorPeeringParams = @{
+  "Name" = "PEER_" + $config.dsg.network.vnet.name
+  "VirtualNetwork" = $mirrorVnet
+  "RemoteVirtualNetworkId" = $dsgVnet.Id
+  "BlockVirtualNetworkAccess" = $FALSE
+  "AllowForwardedTraffic" = $FALSE
+  "AllowGatewayTransit" = $FALSE
+  "UseRemoteGateways" = $FALSE
+}
+Write-Output $mirrorPeeringParams
+Add-AzVirtualNetworkPeering @mirrorPeeringParams
+
+# Switch back to DSG subscription
+Set-AzContext -SubscriptionId $config.dsg.subscriptionName;
+# Add Peering to DSG Vnet
+$dsgPeeringParams = @{
+  "Name" = "PEER_" + $config.shm.mirrors.vnet.name
+  "VirtualNetwork" = $dsgVnet
+  "RemoteVirtualNetworkId" = $mirrorVnet.Id
+  "BlockVirtualNetworkAccess" = $FALSE
+  "AllowForwardedTraffic" = $FALSE
+  "AllowGatewayTransit" = $FALSE
+  "UseRemoteGateways" = $FALSE
+}
+Write-Output $dsgPeeringParams
+Add-AzVirtualNetworkPeering @dsgPeeringParams
+
+# Switch back to original subscription
+Set-AzContext -Context $prevContext;

--- a/new_dsg_environment/dsg_deploy_scripts/DsgConfig.psm1
+++ b/new_dsg_environment/dsg_deploy_scripts/DsgConfig.psm1
@@ -117,9 +117,12 @@ function Add-DsgConfig {
 
     # --- Package mirror config ---
     $config.dsg.mirrors = [ordered]@{
+        vnet = [ordered]@{}
         cran = [ordered]@{}
         pypi = [ordered]@{}
     }
+    $config.dsg.mirrors.vnet.rg = "RG_SH_PKG_MIRRORS"
+    $config.dsg.mirrors.vnet.name = "VNET_SH_PKG_MIRRORS"
     $config.dsg.mirrors.cran.ip = $dsgConfigBase.packageMirrorIpCran
     $config.dsg.mirrors.pypi.ip = $dsgConfigBase.packageMirrorIpPypi
 


### PR DESCRIPTION
- Adds script to add two-way peering between DSG and Mirror VNets
- Updates section 9 of DSG runbook to refer to new Powershell script
- Updates DSG config generator function to add Mirror RG and VNet names
- Regenerates full configs for DSGs 4 and 9-15

Will close #273