### PR TITLE
Add external IP address for Ofsted "DCIB traffic" secure network to DSG2

### DIFF
--- a/new_dsg_environment/dsg_configs/core/dsg_2_core_config.json
+++ b/new_dsg_environment/dsg_configs/core/dsg_2_core_config.json
@@ -5,7 +5,7 @@
     "tier": "3",
     "domain": "dsgroup2.co.uk",
     "ipPrefix": "10.250.8",
-    "rdsAllowedSources": "193.60.220.240,137.205.213.46",
+    "rdsAllowedSources": "193.60.220.240,137.205.213.46,167.98.26.243",
     "computeVmImageType": "Ubuntu",
     "computeVmImageVersion": "0.1.2019061600"
 }

--- a/new_dsg_environment/dsg_configs/full/dsg_2_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_2_full_config.json
@@ -196,7 +196,7 @@
       "nsg": {
         "gateway": {
           "name": "NSG_RDS_Server",
-          "allowedSources": "193.60.220.240,137.205.213.46"
+          "allowedSources": "193.60.220.240,137.205.213.46,167.98.26.243"
         },
         "sessionHosts": {
           "name": "NSG_SessionHosts"


### PR DESCRIPTION
Addresses requirement for access from on site at Ofsted on Tue 23 July 2019 (https://github.com/alan-turing-institute/DSSG-19-issues/issues/34)

From: Marcio Gomes <xxx@ofsted.gov.uk>
Date: Friday, 19 July 2019 at 13:28
To: Martin O'Reilly <xxx@turing.ac.uk>, James Bowsher-Murray <xxx@ofsted.gov.uk>, Joshua Sidgwick <xxx@turing.ac.uk>
Cc: Pablo Rosado <xxx@turing.ac.uk>, "xxx@uchicago.edu" <xxx@uchicago.edu>, Sebastian Vollmer <xxx@turing.ac.uk>, Derek Holt <xxx@ofsted.gov.uk>
Subject: RE: DSSG access to turing safehaven while at ofsted

Hi Martin,
 
As discussed please find Ofsted’s external IP below
 
167.98.26.243 - DCIB Traffic 
 
Thank you
Marcio
 
 
From: Martin O'Reilly <xxx@turing.ac.uk> 
Sent: 19 July 2019 10:03
To: James Bowsher-Murray <xxx@ofsted.gov.uk>; Marcio Gomes <xxx@ofsted.gov.uk>; Joshua Sidgwick <xxx@turing.ac.uk>
Cc: Pablo Rosado <xxx@turing.ac.uk>; xxx@uchicago.edu; Sebastian Vollmer <xxx@turing.ac.uk>; Derek Holt <xxx@ofsted.gov.uk>
Subject: Re: DSSG access to turing safehaven while at ofsted
 
Hi Marcio,
 
Please could you send me the external IP addresses assigned to your corporate network? Whether we go with the guest laptop option or the option of adding Ofsted staff as users in the secure project environment, we'll need to add these IP addresses to the environment whitelist.
 
I've also included my notes of our call on Wednesday below so we've a shared record of our decision.
 
Thanks in advance,
 
Martin
 
### Ofsted options from call 17 July 2019

The Ofsted corporate network meets the Tier 3 requirements with the exception of some VPN access from Ofsted staff. Given the short term nature of the connectivity both sides agreed to accept this as a risk-based exception for the site visit. Therefore managed devices connecting from the Ofsted corporate network will be ok.

We also considered the Ofsted guest network as an option to support connections from the DSSG chromebooks. This has password based access control, with the password changed weekly, but may have other supplier devices connected which may not be managed, so does not meet the Tier 3 requirements. We discussed the option of making a risk-based exception to permit access from this network, as potential unmanaged device connectivity is limited to other suppliers connecting that week, but both sides would much prefer an option that uses the corporate network.

Preferred options

1.	Ofsted to provide a presentation/guest laptop connected to their corporate network and DSSG team to connect to the Tier 3 environment using their credentials and "drive" the presentation / exploration.
2.	Ofsted to nominate one or two staff who will be part of the day and already have access to the Tier 3 data. These staff members will be added to the Ofsted Tier 3 environment and login with their own credentials and "drive" the presentation / exploration from their laptop.

In either case, access will be from the Ofsted corporate network which has a few (4?) external IP addresses, which we will add to the whitelist for the Tier 3 environment until after the site visit next Wednesday.
 
 
From: James Bowsher-Murray <xxx@ofsted.gov.uk>
Sent: 17 July 2019 08:01
To: Marcio Gomes; Martin O'Reilly; Joshua Sidgwick
Cc: Pablo Rosado; xxx@uchicago.edu; Sebastian Vollmer; Derek Holt
Subject: RE: DSSG access to turing safehaven while at ofsted 
 
Thanks Marcio.
 
We’ll set up a call.
 
James
 
 
From: Marcio Gomes 
Sent: 16 July 2019 14:30
To: Martin O'Reilly <xx@turing.ac.uk>; Joshua Sidgwick <xx@turing.ac.uk>; James Bowsher-Murray <xx@ofsted.gov.uk>
Cc: Pablo Rosado <xx@turing.ac.uk>; xx@uchicago.edu; Sebastian Vollmer <xx@turing.ac.uk>; Derek Holt <xx@ofsted.gov.uk>
Subject: RE: DSSG access to turing safehaven while at ofsted
 
Thank you Martin and Joshua,
 
I have had a look at the emails below, please see my comments in red.
 
I think a call would be good to understand the exact requirements and ensure no assumptions are being made.
 
Thank you
Marcio
 
From: Martin O'Reilly <xxx@turing.ac.uk> 
Sent: 16 July 2019 12:54
To: Joshua Sidgwick <xxx@turing.ac.uk>; James Bowsher-Murray <xxx@ofsted.gov.uk>; Marcio Gomes <xxx@ofsted.gov.uk>
Cc: Pablo Rosado <xxx@turing.ac.uk>; xxx@uchicago.edu; Sebastian Vollmer <xxx@turing.ac.uk>
Subject: Re: DSSG access to turing safehaven while at ofsted
 
Hi James / Marcio,
 
In order for the team to be able to access the Tier 3 environment the Ofsted data resides in, the following conditions must be met. 
 
1.	Access is from managed devices only - i.e. devices where users do not have administrator rights – all our users have standard access only to laptops. Some may have an additional admin account but that’s is generally for IS staff.
2.	Access is from “medium security” access controlled physical spaces only - e.g. card controlled access with signing in of visitors on a known list. – Our offices are government secure offices. All need to swipe in for access.
 
Within the Tier 3 environment, we can only restrict access by IP address, so we need a network configuration at your site that allows us to have confidence that all connections from a given set of IP addresses satisfy these criteria. In practice this means:
 
1.	There is a set of IP addresses that will only ever be assigned to managed devices – Each of Ofsted’s offices have set IP addresses which makes them identifiable to their location
2.	These IP addresses are only ever assigned to these managed devices while they are located inside a "medium security" access controlled physical space. - Correct
 
See the end of this email for the full requirements from our policy paper.
 
At the Turing and at Warwick, we have satisfied these criteria by setting up a dedicated DSSG wifi network that (i) restricts access to network to the MAC addresses of the programme’s managed Chromebooks, (ii) is assigned a dedicated externally facing IP address we can whitelist in the Tier 3 environment and (iii) is only broadcast from wireless access points located within a medium security physical space.
 
However, other arrangements are acceptable as long as we can restrict access to a set of IP addresses that will only ever be assigned to managed devices while within a medium security physical space. Note that the managed devices do not need to be DSSG programme devices. For example, if you have an existing staff network that only allows your own managed devices to connect, this would be ok as long as VPN access to this network was not possible (strictly, as long as devices connecting via VPN do not get the same IP address(es) as those connecting locally from within the medium security physical space). In this case, you would need to provide devices for the programme team to use while onsite. The only software requirements for connecting to the Tier 3 environment are a compatible browser (Chrome or Firefox ideally).
 
I’m happy to chat in person about what options are possible at your end. 
 
### Tier 3 policies from paper
Excerpt from section 6.1.1 (managed devices)
>Managed devices must, by default, when issued, not have administrator/root access. They should have an extensive suite of research software installed. This should include the ability to install packages for standard programming environments without use of root (such as pip install, brew install.)Researchers should be able to compile and run executables they code in user space. The setup should include a hypervisor for managing VMs for activities that need root/administrator access - @James Bowsher-Murray You will need to confirm you have the tools you need on your selected users

Excerpt from section 6.3 (restricted networks)
>A Restricted network may be linked between multiple institutions (such as partner research institutions), so that researchers travelling to collaborators’ sites will be able to connect to Restricted networks, and thus to secure environments, while away from their home institution.Remote access to a Restricted network (e.g. via VPN) should not be possible.

Excerpt from 6.4 (medium security physical space) @James Bowsher-Murray Im aware some of your staff work from home and VPN in to Ofsted. Can you see it this is a problem for you please.
>Medium security research spaces control the possibility of unauthorised viewing. Card access or other means of restricting entry to only known researchers (such as the signing in of guests on a known list) is required. Screen adaptations or desk partitions can be adopted in open plan environments if there is a high risk of “visual evesdropping”. Screens must be locked when the user is away from the device.

Excerpt from section 11.2 – Ofsted’s policy is to secure your screen when away from your desk. This is standard practise and its been around for many years at Ofsted. Ofsted’s offices are all open plan
>Only the Restricted network will be able to access Tier 3 and above access nodes.

Excerpt from section 11.4
>Open devices should not be able to access the Restricted network. Managed laptop devices should be able to leave the physical office where the Restricted network exists, but should have no access to Tier 3 or above environments while ’roaming’.

Excerpt from section 11.5
>The restricted network should be located in a medium security physical space.
 
Martin
