### PR TITLE
Take adding data disks to compute VMs from master

### DIFF
--- a/new_dsg_environment/azure-vms/deploy_azure_compute_vm.sh
+++ b/new_dsg_environment/azure-vms/deploy_azure_compute_vm.sh
@@ -31,8 +31,10 @@ RESOURCEGROUP_IMAGES="RG_SH_IMAGE_GALLERY"
 LOCATION="uksouth"
 LDAP_RESOURCEGROUP="RG_SH_LDAP"
 DEPLOYMENT_NSG="NSG_IMAGE_DEPLOYMENT" # NB. this will *allow* internet connection during deployment
-OS_DISK_SIZE_GB="512"
+OS_DISK_SIZE_GB="128"
 OS_DISK_TYPE="Standard_LRS"
+DATA_DISK_SIZE_GB="512"
+DATA_DISK_TYPE="Standard_LRS"
 
 
 # Document usage for this script
@@ -411,6 +413,11 @@ CRAN_MIRROR_IP_REGEX="s/CRAN_MIRROR_IP/${CRAN_MIRROR_IP}/"
 # Substitute regexes
 sed -e "${USERNAME_REGEX}" -e "${LDAP_SECRET_REGEX}" -e "${MACHINE_NAME_REGEX}" -e "${LDAP_USER_REGEX}" -e "${DOMAIN_LOWER_REGEX}" -e "${DOMAIN_UPPER_REGEX}" -e "${LDAP_CN_REGEX}" -e "${LDAP_BASE_DN_REGEX}" -e "${LDAP_FILTER_REGEX}" -e "${LDAP_BIND_DN_REGEX}" -e  "${AD_DC_NAME_UPPER_REGEX}" -e "${AD_DC_NAME_LOWER_REGEX}" -e "${PYPI_MIRROR_IP_REGEX}" -e "${CRAN_MIRROR_IP_REGEX}" $CLOUD_INIT_YAML > $TMP_CLOUD_CONFIG_YAML
 
+# Create the data disk
+echo -e "${BOLD}Creating ${BLUE}${DATA_DISK_SIZE_GB} GB${END}${BOLD} datadisk...${END}"
+DATA_DISK_NAME="${MACHINENAME}DATADISK"
+az disk create --resource-group $RESOURCEGROUP --name $DATA_DISK_NAME --location $LOCATION --sku $DATA_DISK_TYPE --size-gb $DATA_DISK_SIZE_GB --output none
+
 # Create the VM based off the selected source image
 # -------------------------------------------------
 echo -e "${BOLD}Creating VM ${BLUE}$MACHINENAME${END} ${BOLD}as part of ${BLUE}$RESOURCEGROUP${END}"
@@ -423,6 +430,7 @@ if [ "$IP_ADDRESS" = "" ]; then
     az vm create ${PLANDETAILS} \
         --admin-password $ADMIN_PASSWORD \
         --admin-username $USERNAME \
+        --attach-data-disks $DATA_DISK_NAME \
         --custom-data $TMP_CLOUD_CONFIG_YAML \
         --image $IMAGE_ID \
         --name $MACHINENAME \
@@ -440,6 +448,7 @@ else
     az vm create ${PLANDETAILS} \
         --admin-password $ADMIN_PASSWORD \
         --admin-username $USERNAME \
+        --attach-data-disks $DATA_DISK_NAME \
         --custom-data $TMP_CLOUD_CONFIG_YAML \
         --image $IMAGE_ID \
         --name $MACHINENAME \

--- a/new_dsg_environment/dsg_configs/cloud_init/cloud-init-compute-vm-DEFAULT.yaml
+++ b/new_dsg_environment/dsg_configs/cloud_init/cloud-init-compute-vm-DEFAULT.yaml
@@ -167,10 +167,6 @@ runcmd:
   - cp /Rprofile.site /anaconda/envs/py27/lib/R/etc/Rprofile.site
   - cp /Rprofile.site /anaconda/envs/py36/lib/R/etc/Rprofile.site
   - cp /Rprofile.site /anaconda/envs/py37/lib/R/etc/Rprofile.site
-  # Create shared data folder and grant all users access
-  - echo "Creating shared data folder"
-  - sudo mkdir /data
-  - sudo chmod go+rw /data
   # Make sure that sssd is running
   - echo "Restart sssd service"
   - service sssd restart
@@ -194,6 +190,19 @@ runcmd:
   # Restart xrdp to reflect changes made above
   - echo "Restart xrdp"
   - service xrdp restart
+  # Create shared data folder and grant all users access
+  - echo "Creating shared data folder using data disk"
+  - parted /dev/sdc mklabel gpt
+  - parted /dev/sdc mkpart primary ext4 0% 100%
+  - parted /dev/sdc print
+  - sleep 5
+  - mkfs -t ext4 /dev/sdc1
+  - mkdir -p /data
+  - mount /dev/sdc1 /data
+  - chmod go+rw /data
+  - UUID=$(blkid | grep "/dev/sdc1" | cut -d'"' -f2)
+  - sed "s|UUID|UUID=$UUID\t/data\text4\tdefaults,nofail\t1\t2\nUUID|" /etc/fstab > fstab.tmp
+  - mv fstab.tmp /etc/fstab
   # Add execute permission to the Active Directory set up scripts
   - chmod +x /active_directory_step01_pre
   - chmod +x /active_directory_step02_realm_join


### PR DESCRIPTION
Resizing the OS disk on a compute VM requires stopping the VM. With a separate data disk the disk can be resized by unmounting + detaching, resizing, then re-attaching + remounting.