### PR TITLE
Allow access from Bristol EduRoam visitor IP range to Tier 2 DSG19 environment.

### DIFF
--- a/new_dsg_environment/dsg_configs/core/dsg_19_core_config.json
+++ b/new_dsg_environment/dsg_configs/core/dsg_19_core_config.json
@@ -6,7 +6,7 @@
     "domain": "dsgroup19.co.uk",
     "netbiosname": "DSGROUP19",
     "ipPrefix": "10.250.144",
-    "rdsAllowedSources": "137.222.0.0/16,193.60.220.253,193.60.220.240,193.60.198.0-193.60.198.127",
+    "rdsAllowedSources": "137.222.0.0/16,193.60.220.253,193.60.220.240,193.60.198.0/25",
     "computeVmImageType": "Ubuntu",
     "computeVmImageVersion": "0.1.2019071900"
 }

--- a/new_dsg_environment/dsg_configs/full/dsg_19_full_config.json
+++ b/new_dsg_environment/dsg_configs/full/dsg_19_full_config.json
@@ -210,7 +210,7 @@
       "nsg": {
         "gateway": {
           "name": "NSG_RDS_Server",
-          "allowedSources": "137.222.0.0/16,193.60.220.253,193.60.220.240,193.60.198.0-193.60.198.127"
+          "allowedSources": "137.222.0.0/16,193.60.220.253,193.60.220.240,193.60.198.0/25"
         },
         "sessionHosts": {
           "name": "NSG_SessionHosts"


### PR DESCRIPTION
Addresses [issue 1](https://github.com/alan-turing-institute/DSG-Bristol-Aug2019-Issues/issues/1) in the DSG Bristol August 2019 issue tracker.

This PR adds the IP range `193.60.198.0 - 193.60.198.127`, which is allocated to the University of Bristol according to its  [RIPE entry](https://apps.db.ripe.net/db-web-ui/#/lookup?source=ripe&key=193.60.198.0%20-%20193.60.198.127&type=inetnum)