### PR TITLE
Fix xfce issues

### DIFF
--- a/new_dsg_environment/dsg_configs/cloud_init/cloud-init-compute-vm-DEFAULT.yaml
+++ b/new_dsg_environment/dsg_configs/cloud_init/cloud-init-compute-vm-DEFAULT.yaml
@@ -186,12 +186,12 @@ runcmd:
   - mv /startwm.sh /etc/xrdp/startwm.sh
   - chmod 0755 /etc/xrdp/startwm.sh
   - echo xfce4-session > ~USERNAME/.xsession
-  # Set default terminal for xfce
-  - echo "Set default xfce terminal"
-  - sed -i -E 's/(TerminalEmulator=).*/\1xfce4-terminal/' /etc/xdg/xfce4/helpers.rc
   # Ensure that user owns their home directory
   - echo "Ensure that user owns their home directory"
   - chown -R USERNAME ~USERNAME
+  # Set default terminal for xfce
+  - echo "Set default xfce terminal"
+  - sed -i -E 's/(TerminalEmulator=).*/\1xfce4-terminal/' /etc/xdg/xfce4/helpers.rc
   # Disable thinclients_drive folder created by xrdp
   - sed -i "s/allow_channels=true/allow_channels=false/" /etc/xrdp/xrdp.ini
   # Restart xrdp to reflect changes made above


### PR DESCRIPTION
This disables the thinclient_drive folder for future compute VM deployments (won't affect current deployments).

It also adds a script implementing (https://github.com/alan-turing-institute/data-safe-haven/issues/409#issuecomment-518852652) but this does not yet work as advertised (has not successfully reset my panel on a test session).

Addresses #391. Addresses part of #409.