### PR TITLE
Added python packages requested by DSSG

### DIFF
--- a/new_dsg_environment/azure-vms/package_lists/tier3_pypi_whitelist.list
+++ b/new_dsg_environment/azure-vms/package_lists/tier3_pypi_whitelist.list
@@ -38,6 +38,7 @@ boto3
 botocore
 Bottleneck
 box2d-py
+bpemb
 branca
 bz2file
 catboost
@@ -55,6 +56,7 @@ constantly
 contextlib2
 convertdate
 cryptography
+cycler
 Cycler
 cymem
 Cython
@@ -68,6 +70,7 @@ dask
 DataShape
 decorator
 defusedxml
+deprecated
 descartes
 distributed
 docutils
@@ -100,6 +103,7 @@ gmpy2
 GPy
 GPyOpt
 graph-tool
+graphviz
 grpcio
 gym
 h5py
@@ -108,6 +112,7 @@ holidays
 html5lib
 httplib2
 hyperlink
+hyperopt
 idna
 imageio
 imagesize
@@ -121,6 +126,7 @@ ipywidgets
 isort
 itsdangerous
 jedi
+jinja2
 Jinja2
 jmespath
 joblib
@@ -160,6 +166,7 @@ mock
 monocle
 more-itertools
 mpi4py
+mpld3
 mpmath
 msgpack
 multipledispatch
@@ -219,6 +226,7 @@ pycairo
 pycodestyle
 pycosat
 pycparser
+pycryptodome
 pycurl
 pyglet
 Pygments
@@ -229,12 +237,12 @@ PyJWT
 pyLDAvis
 pylint
 pymc3
+pymongo
 pyod
 PyOpenGL
 PyOpenGL-accelerate
 pyOpenSSL
 pyparsing
-PyPDF2
 PyPDF2
 pyproj
 pyrsistent
@@ -252,6 +260,7 @@ python-editor
 python-geohash
 python-louvain
 pytorch
+pytorch-pretrained-bert
 pytz
 PyWavelets
 PyYAML
@@ -269,7 +278,9 @@ scikit-image
 scikit-learn
 scipy
 seaborn
+segtok
 Send2Trash
+sentencepiece
 service_identity
 setuptools
 setuptools-git
@@ -278,6 +289,7 @@ simplegeneric
 singledispatch
 SIP
 six
+sklearn
 smart-open
 snowballstemmer
 sortedcontainers
@@ -293,6 +305,7 @@ sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
 sphinxcontrib-websupport
 SQLAlchemy
+sqlitedict
 srsly
 statsmodels
 subprocess32


### PR DESCRIPTION
Added python libraries requested in https://github.com/alan-turing-institute/DSSG-19-issues/issues/53 to the Tier-3 whitelist.

According to `libraries.io` none of these packages have any dependencies which seems unlikely. I ran a test on my desktop and installing these packages results in the following requirements:

```
typing, MarkupSafe, jinja2, six, joblib, numpy, scipy, scikit-learn, attrs, graphviz, tabulate, eli5, more-itertools, pyparsing, packaging, py, zipp, importlib-metadata, pluggy, wcwidth, atomicwrites, pytest, docutils, python-dateutil, jmespath, urllib3, botocore, s3transfer, boto3, chardet, idna, certifi, requests, tqdm, torch, regex, pytorch-pretrained-bert, boto, smart-open, gensim, sentencepiece, bpemb, sqlitedict, decorator, networkx, pymongo, future, hyperopt, segtok, wrapt, deprecated, sklearn, kiwisolver, cycler, matplotlib, mpld3, flair, pycryptodome, sortedcontainers, pdfminer.six, PyPDF2
```