### PR TITLE
Cross-reference webapp repository docs for creating new users.

### DIFF
--- a/new_dsg_environment/create-users/README.md
+++ b/new_dsg_environment/create-users/README.md
@@ -1,6 +1,17 @@
-# Creating new users without the app
+# Creating new users (Project Investigator or Programme Manager)
 
-## Create new user file (Project Investigator or Research Co-ordinator)
+## Creating new users using the web app
+
+- Follow the [instructions in the webapp repository](https://github.com/alan-turing-institute/data-safe-haven-webapp/blob/master/runbooks/create-users/create-users.md) to create users.
+  - Users can be created in bulk by selecting `Create User > Import user list` and uploading a spreadsheet of user details  
+  - Users can also be created individually by selecting `Create User > Create Single User`
+- After creating users, export the `UserCreate.csv` file
+  - To export all users, select `Users > Export UserCreate.csv`
+  - To export only users for a particular project, select `Projects > (Project Name) > Export UserCreate.csv`
+- Send the file to IT
+
+## Creating new users without the web app
+
 - Make a new copy of the user details file `UserCreate.csv`, naming it `YYYYDDMM-HHMM_UserCreate.csv`
 - Add the required details for each user
   - `SamAccountName`: Log in username **without** the @domain bit). Use `firstname.lastname` format


### PR DESCRIPTION
Completes alan-turing-institute/data-safe-haven-webapp#88. Added additional documentation to refer to the webapp documentation when creating users, to make clear the workflow for creating users via the webapp.