### PR TITLE
Fix GitLab cloud-init installation

### DIFF
--- a/deployment/secure_research_environment/cloud_init/cloud-init-gitlab.template.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-gitlab.template.yaml
@@ -21,7 +21,7 @@ apt:
   sources:
     gitlab.list:
       source: "deb https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu bionic main"
-      keyid: 14219A96E15E78F4
+      keyid: 3F01618A51312F3F
 
 write_files:
   - path: /etc/gitlab/gitlab.rb


### PR DESCRIPTION
The gitlab repo key has changed (https://docs.gitlab.com/omnibus/update/package_signatures.html).

Without this update, GitLab cannot be installed as the repository is untrusted. This fix is also necessary for testing the code ingress work that @ots22 @jack89roberts @nbarlowATI are doing.