### PR TITLE
WIP: GitHub action to build pdfs from markdown documentation

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and upload the pdfs to a release
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Build a pdf from each markdown file in `docs/` whenever anything in this directory is modified on master.  This updates the tag `latest-doc` to point to the current commit, and makes a release (actually, a pre-release) with the pdf files assets of it.

The pdf documentation is then available as `https://github.com/alan-turing-institute/data-safe-haven/releases/download/latest-doc/*.pdf`.
