### PR TITLE
Add weka to DSVM build image

### DIFF
--- a/deployment/dsvm_images/cloud_init/cloud-init-buildimage-ubuntu.yaml
+++ b/deployment/dsvm_images/cloud_init/cloud-init-buildimage-ubuntu.yaml
@@ -418,6 +418,8 @@ runcmd:
   - if [ "$(which nvidia-smi)" ]; then echo "\n\n*nvidia-smi*\n\n$(which nvidia-smi)\n$(modinfo nvidia | grep '^version:')"; else echo "nvidia-ERROR smi not found!"; exit 1; fi
   - if [ "$(which psql)" ]; then echo "\n\n*psql*\n\n$(which psql)\n$(psql --version)"; else echo "ERROR psql not found!"; exit 1; fi
   - if [ "$(which sqlcmd)" ]; then echo "\n\n*sqlcmd*\n\n$(which sqlcmd)\n$(sqlcmd -? | grep Version)"; else echo "ERROR sqlcmd not found!"; exit 1; fi
+  # Data Science tools
+  - if [ "$(which weka)" ]; then echo "\n\n*weka*\n\n$(which weka)\n$(weka -c weka.core.Version | head -n 1)"; else echo "ERROR weka not found!"; exit 1; fi
 
 
 final_message:

--- a/deployment/dsvm_images/packages/packages-apt.list
+++ b/deployment/dsvm_images/packages/packages-apt.list
@@ -295,6 +295,8 @@ texlive-full
 texstudio
 unicode
 unzip
+weka
+weka-doc
 xfce4
 xfce4-terminal
 xrdp


### PR DESCRIPTION
Adds weka to the DS VM build image.

Image version **0.2.2020051900** includes these changes. Weka version is 3.6.14.

Tested by attaching to the Test A Sandbox SRE - Weka icon appears under "Education" in the applications menu and the GUI seems to work normally (at least no obvious errors). 

Closes #641.