### PR TITLE
Fix Tier-2 mirror deployments

### DIFF
--- a/deployment/safe_haven_management_environment/setup/Setup_SHM_Package_Mirrors.ps1
+++ b/deployment/safe_haven_management_environment/setup/Setup_SHM_Package_Mirrors.ps1
@@ -207,7 +207,7 @@ function Deploy-PackageMirror {
     # --------------------
     $cloudInitPath = Join-Path $PSScriptRoot ".." "cloud_init" "cloud-init-mirror-${mirrorDirection}-${MirrorType}.yaml".ToLower()
     $fullMirrorType = "${MirrorType}".ToLower().Replace("cran", "r-cran").Replace("pypi", "python-pypi")
-    $whitelistPath = Join-Path $PSScriptRoot ".." ".." ".." "environment_configs" "package_lists" "whitelist-core-${fullMirrorType}-tier${tier}.list".ToLower() -Resolve
+    $whitelistPath = Join-Path $PSScriptRoot ".." ".." ".." "environment_configs" "package_lists" "whitelist-core-${fullMirrorType}-tier${tier}.list".ToLower() # do not resolve this path as we have not tested whether it exists yet
     $cloudInitYaml = Resolve-CloudInit -MirrorType $MirrorType -MirrorDirection $MirrorDirection -CloudInitPath $cloudInitPath -WhitelistPath $whitelistPath
 
     # Construct IP address for this mirror


### PR DESCRIPTION
The package mirror deployment code currently tries to resolve the whitelist path before checking whether or not the file exists. This causes an error for Tier-2 mirrors and is not actually needed.