### PR TITLE
Add setuptools-scm

### DIFF
--- a/environment_configs/package_lists/whitelist-core-python-pypi-tier3.list
+++ b/environment_configs/package_lists/whitelist-core-python-pypi-tier3.list
@@ -337,6 +337,7 @@ Send2Trash
 sentencepiece
 service_identity
 setuptools
+setuptools-scm
 setuptools-git
 Shapely
 simplegeneric


### PR DESCRIPTION
 - Add setuptools-scm to the PyPI whitelist

This package is required by `scikit-survival` but this dependency was not previously picked up.