### PR TITLE
Add forceUpgrade option in Add_DSVM script

### DIFF
--- a/deployment/secure_research_environment/setup/Add_DSVM.ps1
+++ b/deployment/secure_research_environment/setup/Add_DSVM.ps1
@@ -6,7 +6,9 @@ param(
     [Parameter(Position = 2,Mandatory = $false,HelpMessage = "Enter VM size to use (or leave empty to use default)")]
     [string]$vmSize = "",
     [Parameter(Position = 3,Mandatory = $false,HelpMessage = "Perform an in-place upgrade.")]
-    [switch]$upgrade
+    [switch]$upgrade,
+    [Parameter(Position = 4,Mandatory = $false,HelpMessage = "Force an in-place upgrade.")]
+    [switch]$forceUpgrade
 )
 
 Import-Module Az
@@ -60,8 +62,8 @@ if ($upgrade) {
 
     # Ensure that an upgrade will occur
     # ---------------------------------
-    if ($existingVmName -eq $vmName) {
-        Add-LogMessage -Level InfoSuccess "The existing VM appears to be using the same image version, no upgrade will occur"
+    if ($existingVmName -eq $vmName -and -not $forceUpgrade) {
+        Add-LogMessage -Level InfoSuccess "The existing VM appears to be using the same image version, no upgrade will occur. Use -forceUpgrade to ignore this"
         $_ = Set-AzContext -Context $originalContext
         exit 0
     }


### PR DESCRIPTION
Cherry picks commit 4d58793f8b0b51a81f762b667389a23377edd971 to add the `forceUpgrade` option in the DSVM deployment script.

This is needed to roll-out the VM upgrade in #715 (since the VM image version is unchanged in the upgraded DSVM).