### PR TITLE
Improved random password generator

### DIFF
--- a/deployment/common/Security.psm1
+++ b/deployment/common/Security.psm1
@@ -1,7 +1,9 @@
 Import-Module $PSScriptRoot/Logging.psm1
 
 # Generate a random alphanumeric password
-# ---------------------------------------
+# This gives a verifiably flat distribution across the characters in question
+# We introduce bias by the password requirements which increase the proportion of digits
+# --------------------------------------------------------------------------------------
 function New-Password {
     param(
         [int]$Length = 20
@@ -41,7 +43,8 @@ Export-ModuleMember -Function New-Password
 
 
 # Create a string of random letters
-# ---------------------------------
+# Note that this is not cryptographically secure but does give a verifiably flat distribution across lower-case letters
+# ---------------------------------------------------------------------------------------------------------------------
 function New-RandomLetters {
     param(
         [int]$Length = 20,


### PR DESCRIPTION
I think this method of generating passwords is simpler, involves less code and should be more random than the previous method. However, cryptography/randomness are notorious for solutions that look sensible but aren't so I'd like to get other people's thoughts on this.

The random number source remains the same as before, but instead of taking `$randomByte % 62` which disproportionately favours low numbers [eg. 3 will show up 5 times for each 4 times that 37 shows up], we now take four random bytes and convert them to a `uint32`. We establish a ceiling which is the maximum `uint32` that is exactly divisible by 62 - random numbers above this are discarded (which very rarely happens as this is at most 62 out of 2^32 possibilities). Anything below this ceiling can be trivially converted into a number in the range `0..61` by applying `% 62` which should be uniformly distributed between 0 and 61.

**Note** An earlier version of this code divided by `uint::max` to get a float and then multiplied by 62, but this introduces unnecessary float precision errors. This is what is referred to in @thobson88's "New method" comparision below.

Thoughts?