### PR TITLE
Restrict outbound firewall rules to allow HTTPS only

### DIFF
--- a/deployment/safe_haven_management_environment/network_rules/shm-firewall-rules.json
+++ b/deployment/safe_haven_management_environment/network_rules/shm-firewall-rules.json
@@ -36,7 +36,6 @@
                             "AzureActiveDirectory"
                         ],
                         "destinationPorts": [
-                            "80",
                             "443"
                         ]
                     }
@@ -82,8 +81,7 @@
                     {
                         "name": "ADConnectPasswordReset",
                         "protocols": [
-                            "https:443",
-                            "http:80"
+                            "https:443"
                         ],
                         "fqdnTags": [],
                         "targetFqdns": [
@@ -98,8 +96,7 @@
                     {
                         "name": "ADConnectHealthCheck",
                         "protocols": [
-                            "https:443",
-                            "http:80"
+                            "https:443"
                         ],
                         "fqdnTags": [],
                         "targetFqdns": [


### PR DESCRIPTION
Network Rule changes
- Remove port 80 from AzureActiveDirectory rule

Application Rule changes
- Remove port 80 from ADConnectPasswordReset rule
- Remove port 80 from ADConnectHealthCheck rule