### PR TITLE
Remove multiple references to RDS

### DIFF
--- a/docs/deploy_shm_instructions.md
+++ b/docs/deploy_shm_instructions.md
@@ -528,19 +528,19 @@ Once you're certain that you're adding a new user, make sure that the following 
 - Open a Powershell terminal and navigate to the `deployment/safe_haven_management_environment/setup` directory within the Safe Haven repository.
 - Ensure you are logged into Azure within PowerShell using the command: `Connect-AzAccount`
     - NB. If your account is a guest in additional Azure tenants, you may need to add the `-Tenant <Tenant ID>` flag, where `<Tenant ID>` is the ID of the Azure tenant you want to deploy into.
-- Deploy and configure the NPS VMs by running `./Setup_SHM_NPS.ps1 -shmId <SHM ID>`, where the SHM ID is the one specified in the config
+- Deploy and configure the NPS VM by running `./Setup_SHM_NPS.ps1 -shmId <SHM ID>`, where the SHM ID is the one specified in the config
 - This will take **around 20 minutes** to run.
     - **Troubleshooting:** If you see an error similar to `New-AzResourceGroupDeployment : Resource Microsoft.Compute/virtualMachines/extensions NPS-SHM-<SHM ID>/joindomain' failed with message` you may find this error resolves if you wait and retry later. Alternatively, you can try deleting the extension from the `NPS-SHM-<SHM ID> > Extensions` blade in the Azure portal.
 
-### Configure NPS server
-1. Log in to the NPS Server VM using Microsoft Remote Desktop
+### Configure NPS
+1. Log in to the NPS VM using Microsoft Remote Desktop
     - the private IP address for the SHM NPS VM can be found in the `RG_SHM_NPS` resource group
     - the Username and Password are the same as for `DC1-SHM` and `DC2-SHM` (ie the credentials you used above to Remote Desktop into the domain controller above):
     - To obtain the login credentials again, on the Azure portal navigate to the `RG_SHM_SECRETS` resource group and then the `kv-shm-<SHM ID>` key vault and then select `secrets` on the left hand panel.
     - The username is the `shm-<SHM ID>-vm-admin-username` secret plus the domain, ie `<admin username>@custom domain`
     - The password in the `shm-<SHM ID>-domain-admin-password` secret.
 2. In Server Manager select `Tools > Network Policy Server` (or open the `Network Policy Server` desktop app directly)
-3. Configure NPS server to log to a local text file:
+3. Configure NPS to log to a local text file:
     - Select `NPS (Local) > Accounting` on the left-hand sidebar
       <p align="center">
           <img src="images/deploy_shm/nps_accounting.png" width="80%" title="NPS accounting">
@@ -579,7 +579,7 @@ Once you're certain that you're adding a new user, make sure that the following 
 3. When prompted to `Provide your Tenant ID`, enter your Azure Active Directory ID. To get this:
     - In the Azure portal select `Azure Active Directory` in the left hand side bar
     - Select `Properties` in the left hand side bar
-    - Copy the `Directory ID` field and enter it at the prompt on the NPS server
+    - Copy the `Directory ID` field and enter it at the prompt on the NPS
     - **Troubleshooting:** If you see an error `New-MsolServicePrincipalCredential : Service principal was not found`, this indicates that the `Azure Multi-Factor Auth Client` is not enabled in Azure Active Directory.
         - Look at [the documentation here](https://docs.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-nps-extension#troubleshooting).
         - Make sure the Safe Haven Azure Active Directory has valid P1 licenses:
@@ -591,7 +591,7 @@ Once you're certain that you're adding a new user, make sure that the following 
       - Make sure that you have added a P1 licence to at least one user in the `Azure Active Directory` and have gone through the MFA setup procedure for that user. You may have to wait a few minutes after doing this
       - If you've done all of these things and nothing is working, you may have accidentally removed the `Azure Multi-Factor Auth Client` Enterprise Application from your `Azure Active Directory`. Run `C:\Installation\Ensure_MFA_SP_AAD.ps1` to create a new service principal and try the previous steps again.
     - **Troubleshooting:** If you get a `New-MsolServicePrincipalCredential: Access denied` error stating `You do not have permissions to call this cmdlet`, check the following:
-      - Make sure you are logged in to the NPS server as a **domain** user rather than a local user.
+      - Make sure you are logged in to the NPS as a **domain** user rather than a local user.
         - The output of the `whoami` command in Powershell should be `<SHM netBios domain>\admin` rather than `NPS-SHM-<SHM ID>\admin`.
         - If it is not, reconnect to the remote desktop with the username `admin@<SHM domain>`, using the same password as before
       - Make sure you authenticate to `Azure Active Directory` your own **internal** Global Administrator (i.e. `admin.forstname.lastname@<SHM domain>`) and that you have successfully logged in and verified your ohone number + email address and c onfigured MFA on your account.


### PR DESCRIPTION
I found multiple (and I think incorrect) references to RDS VMs in the SHM deployment documentation.

I'm not certain if what I have changed them to is correct or if there are other similar errors elsewhere.