### PR TITLE
Disable legacy TLS on RDS Gateway

### DIFF
--- a/deployment/secure_research_environment/remote/create_rds/scripts/Disable_Legacy_TLS_Remote.ps1
+++ b/deployment/secure_research_environment/remote/create_rds/scripts/Disable_Legacy_TLS_Remote.ps1
@@ -9,12 +9,12 @@ function Disable-ProtocolForRole {
         $Role
     )
     # Disable protocol for role
-    New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Force | Out-Null 
-    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Name 'Enabled' -Value '0' -PropertyType 'DWord' -Force | Out-Null 
-    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Name 'DisabledByDefault' -Value 1 -PropertyType 'DWord' -Force | Out-Null 
+    New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Force | Out-Null
+    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Name 'Enabled' -Value '0' -PropertyType 'DWord' -Force | Out-Null
+    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role" -Name 'DisabledByDefault' -Value 1 -PropertyType 'DWord' -Force | Out-Null
     # Check status
     $status = Get-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\$Protocol\$Role"
-    if((-not $status.GetValue("Enabled")) -and $status.GetValue("DisabledByDefault")) {
+    if ((-not $status.GetValue("Enabled")) -and $status.GetValue("DisabledByDefault")) {
         Write-Output " [o] '$Protocol' protocol is disabled for '$Role' role."
     } else {
         Write-Output " [x] Failed to ensure '$Protocol' protocol is disabled for '$Role' role."
@@ -46,7 +46,7 @@ Write-Output "Ensuring weak TLS cipher suites are disabled..."
 # listed in the table of preferred secure cipher suites at
 # https://www.acunetix.com/blog/articles/tls-ssl-cipher-hardening/
 # NOTE: We exclude known weak suites, rather than restrict ourselved to
-# known strong suites, as additional stronger suites may be introduced 
+# known strong suites, as additional stronger suites may be introduced
 # over time (e.g. with the rollout of general availability support for
 # TLS 3.0).
 $weakCipherSuites = @(
@@ -77,7 +77,7 @@ $weakCipherSuites = @(
     "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
 )
 foreach ($cipherSuite in $WeakCipherSuites) {
-    if(Get-TlsCipherSuite -Name $cipherSuite) {
+    if (Get-TlsCipherSuite -Name $cipherSuite) {
         Disable-TlsCipherSuite -Name $cipherSuite
         if ($?) {
             Write-Output " [o] Disabled '$cipherSuite' suite."

--- a/deployment/secure_research_environment/setup/Disable_Legacy_TLS.ps1
+++ b/deployment/secure_research_environment/setup/Disable_Legacy_TLS.ps1
@@ -6,10 +6,7 @@ param(
 Import-Module Az
 Import-Module $PSScriptRoot/../../common/Configuration.psm1 -Force
 Import-Module $PSScriptRoot/../../common/Deployments.psm1 -Force
-Import-Module $PSScriptRoot/../../common/GenerateSasToken.psm1 -Force
 Import-Module $PSScriptRoot/../../common/Logging.psm1 -Force
-Import-Module $PSScriptRoot/../../common/Networking.psm1 -Force
-Import-Module $PSScriptRoot/../../common/Security.psm1 -Force
 
 
 # Get config and original context before changing subscription
@@ -34,4 +31,4 @@ Enable-AzVM -Name $config.sre.rds.gateway.vmName -ResourceGroupName $config.sre.
 
 # Switch back to original subscription
 # ------------------------------------
-$null = Set-AzContext -Context $originalContext;
+$null = Set-AzContext -Context $originalContext

--- a/deployment/secure_research_environment/setup/Setup_SRE_VNET_RDS.ps1
+++ b/deployment/secure_research_environment/setup/Setup_SRE_VNET_RDS.ps1
@@ -373,8 +373,8 @@ foreach ($nameVMNameParamsPair in $vmNamePairs) {
 # Disable legacy TLS protocols on RDS Gateway
 # -------------------------------------------
 Add-LogMessage -Level Info "[ ] Disabling legacy SSL/TLS protocols on RDS Gateway"
-$ScriptPath = Join-Path $PSScriptRoot ".." "remote" "create_rds" "scripts" "Disable_Legacy_TLS_Remote.ps1"
-$result = Invoke-RemoteScript -Shell "PowerShell" -ScriptPath $ScriptPath -VMName $config.sre.rds.gateway.vmName -ResourceGroupName $config.sre.rds.rg
+$scriptPath = Join-Path $PSScriptRoot ".." "remote" "create_rds" "scripts" "Disable_Legacy_TLS_Remote.ps1"
+$result = Invoke-RemoteScript -Shell "PowerShell" -ScriptPath $scriptPath -VMName $config.sre.rds.gateway.vmName -ResourceGroupName $config.sre.rds.rg
 Write-Output $result.Value
 
 


### PR DESCRIPTION
Disables support for the following SSL/TLS protocols:
- SSL 2.0 (not enabled in default configuration)
- SSL 3.0 (not enabled in default configuration)
- TLS 1.0 (enabled in default configuration)
- TLS 1.1 (enabled in default configuration)

Disables support for weak TLS cipher suites, defined as:
- All TLS cipher suites installed on a Windows Server 2019 VM deployed on Azure
   on 09 July 2020 and **not** listed in the table of preferred secure cipher suites at
   https://www.acunetix.com/blog/articles/tls-ssl-cipher-hardening/
- We exclude known weak suites, rather than restrict ourselves to known strong suites,
   as additional stronger suites may be introduced over time (e.g. with the rollout of general
   availability support for TLS 3.0).

Closes #623