### PR TITLE
Support asynchronous stopping of firewall

### DIFF
--- a/deployment/administration/SHM_Manage_VMs.ps1
+++ b/deployment/administration/SHM_Manage_VMs.ps1
@@ -86,7 +86,7 @@ switch ($Action) {
             }
         }
         if (-not $ExcludeFirewall) {
-            $null = Stop-Firewall -Name $config.firewall.name -ResourceGroupName $config.network.vnet.rg -AsJob
+            $null = Stop-Firewall -Name $config.firewall.name -ResourceGroupName $config.network.vnet.rg -NoWait
         }
     }
 }

--- a/deployment/common/Deployments.psm1
+++ b/deployment/common/Deployments.psm1
@@ -1378,7 +1378,7 @@ function Stop-Firewall {
         [Parameter(Mandatory = $true, HelpMessage = "Name of Firewall resource group")]
         $ResourceGroupName,
         [Parameter(Mandatory = $false, HelpMessage = "Submit request to stop but don't wait for completion.")]
-        [switch]$AsJob
+        [switch]$NoWait
     )
     Add-LogMessage -Level Info "Ensuring that firewall '$Name' is deallocated..."
     $firewall = Get-AzFirewall -Name $Name -ResourceGroupName $ResourceGroupName -ErrorVariable notExists -ErrorAction SilentlyContinue
@@ -1394,8 +1394,8 @@ function Stop-Firewall {
     } else {
         Add-LogMessage -Level Info "[ ] Deallocating firewall '$Name'..."
         $firewall.Deallocate()
-        $firewall = Set-AzFirewall -AzureFirewall $firewall -AsJob:$AsJob -ErrorAction Stop
-        if ($AsJob) {
+        $firewall = Set-AzFirewall -AzureFirewall $firewall -AsJob:$NoWait -ErrorAction Stop
+        if ($NoWait) {
             Add-LogMessage -Level Success "Request to deallocate firewall '$Name' accepted."
         } else {
             Add-LogMessage -Level Success "Firewall '$Name' successfully deallocated."


### PR DESCRIPTION
### Description
:orange_book: Stopping the Firewall takes ~15 minutes, so the `SHM_Manage_VMs.ps1` script doesn't stop it by default, instead requiring the user to pass an explicit `-DeallocateFirewall` flag. This means that stopping all safe haven resources in a "fire and forget" way at the end of a development day is currently only possible by shutting down all SRE VMs first and then closing your laptop while the SHM shutdown script is waiting for the firewall to stop.

This PR adds an `-AsJob` flag to the `Stop-Firewall` function, passing it to the underlying call to `Set-AzFirewall` if provided. This submits a request to shutdown the firewall and returns without waiting for it to complete. The `SHM_Manage_VMs.ps1` script now passes this flag when shutting down the firewall, as well as changing its default behaviour to shutdown the firewall when shutting down SHM VMs, unless the user passes an explicit `-ExcludeFirewall` flag.

### Tests
#### Exclude firewall when shutting down VMs using -ExcludeFirewall flag
```pwsh
PS /Users/moreilly/Source/Turing/data-safe-haven> ./deployment/administration/SHM_Manage_VMs.ps1 -shmId mortest -Group Identity -Action EnsureStopped -ExcludeFirewall
2020-09-02 23:55:28 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_DC' are stopped...
2020-09-02 23:55:29 [   INFO]: [ ] Deallocating VM 'DC1-SHM-MORTEST'
2020-09-02 23:55:29 [SUCCESS]: [✔] Request to deallocate VM 'DC1-SHM-MORTEST' accepted.
2020-09-02 23:55:30 [   INFO]: [ ] Deallocating VM 'DC2-SHM-MORTEST'
2020-09-02 23:55:30 [SUCCESS]: [✔] Request to deallocate VM 'DC2-SHM-MORTEST' accepted.
2020-09-02 23:55:30 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_NPS' are stopped...
2020-09-02 23:55:31 [   INFO]: [ ] Deallocating VM 'NPS-SHM-MORTEST'
2020-09-02 23:55:32 [SUCCESS]: [✔] Request to deallocate VM 'NPS-SHM-MORTEST' accepted.
PS /Users/moreilly/Source/Turing/data-safe-haven>
```

#### Include fireall by default when shutting down VMs
```pwsh
PS /Users/moreilly/Source/Turing/data-safe-haven> ./deployment/administration/SHM_Manage_VMs.ps1 -shmId mortest -Group Identity -Action EnsureStopped                 
2020-09-02 23:56:02 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_DC' are stopped...
2020-09-02 23:56:02 [   INFO]: [ ] Deallocating VM 'DC1-SHM-MORTEST'
2020-09-02 23:56:02 [SUCCESS]: [✔] Request to deallocate VM 'DC1-SHM-MORTEST' accepted.
2020-09-02 23:56:03 [   INFO]: [ ] Deallocating VM 'DC2-SHM-MORTEST'
2020-09-02 23:56:04 [SUCCESS]: [✔] Request to deallocate VM 'DC2-SHM-MORTEST' accepted.
2020-09-02 23:56:04 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_NPS' are stopped...
2020-09-02 23:56:04 [   INFO]: [ ] Deallocating VM 'NPS-SHM-MORTEST'
2020-09-02 23:56:05 [SUCCESS]: [✔] Request to deallocate VM 'NPS-SHM-MORTEST' accepted.
2020-09-02 23:56:05 [   INFO]: Ensuring that firewall 'FIREWALL-SHM-MORTEST' is deallocated...
2020-09-02 23:56:06 [   INFO]: [ ] Deallocating firewall 'FIREWALL-SHM-MORTEST'...
2020-09-02 23:56:06 [SUCCESS]: [✔] Request to deallocate firewall 'FIREWALL-SHM-MORTEST' accepted.
PS /Users/moreilly/Source/Turing/data-safe-haven> 
```

#### Confirm firewall is actually shutdown
```pwsh
PS /Users/moreilly/Source/Turing/data-safe-haven> ./deployment/administration/SHM_Manage_VMs.ps1 -shmId mortest -Group Identity -Action EnsureStopped
2020-09-03 00:11:59 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_DC' are stopped...
2020-09-03 00:12:00 [SUCCESS]: [✔] VM 'DC1-SHM-MORTEST' already deallocated.
2020-09-03 00:12:01 [SUCCESS]: [✔] VM 'DC2-SHM-MORTEST' already deallocated.
2020-09-03 00:12:01 [   INFO]: Ensuring VMs in resource group 'RG_SHM_MORTEST_NPS' are stopped...
2020-09-03 00:12:02 [SUCCESS]: [✔] VM 'NPS-SHM-MORTEST' already deallocated.
2020-09-03 00:12:02 [   INFO]: Ensuring that firewall 'FIREWALL-SHM-MORTEST' is deallocated...
2020-09-03 00:12:03 [SUCCESS]: [✔] Firewall 'FIREWALL-SHM-MORTEST' is already deallocated.
PS /Users/moreilly/Source/Turing/data-safe-haven> 
```