### PR TITLE
Correct links in tutorials README

### DIFF
--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -22,5 +22,5 @@ We provide deployment scripts and detailed deployment guides to allow you to dep
   + Deploy a single Safe Haven Management (SHM) segment. This will deploy the user management and software package mirrors.
 + [Data Science virtual machine build instructions](deployment_tutorials/how-to-customise-dsvm-image.md)
   + Build and publish our "batteries included" Data Science Compute virtual machine image. Customise if necessary.
-+ [Secure Research Environment (SRE) deployment guide](deployment_tutorials/how-to-deploy-sre)
++ [Secure Research Environment (SRE) deployment guide](deployment_tutorials/how-to-deploy-sre.md)
   + Deploy one Secure Research Environment (SRE) for each project you want to have its own independent, isolated analysis environment.


### PR DESCRIPTION
### :orange_book:  Description
Corrects the paths of the tutorial documents in the README for the tutorials directory.

### :closed_umbrella: Related issues
Contributes to #825 
