### PR TITLE
Add domain to localadsync username

### DIFF
--- a/docs/tutorial/deployment_tutorials/how-to-deploy-shm.md
+++ b/docs/tutorial/deployment_tutorials/how-to-deploy-shm.md
@@ -446,7 +446,8 @@ From your **deployment machine**
     + On the `AD forest account` pop-up:
       + Select `Use existing AD account`
       + Enter the details for the `localadsync` user.
-        + Username: use the `shm-<SHM ID>-aad-localsync-username` secret in the SHM Key Vault prepended with `<domain name>\` e.g. `testa.turingsafehaven.ac.uk\testalocaladsync` if the domain is `testa.turingsafehaven.ac.uk` and the value of the secret is `testalocaladsync`.
+        + Username: use the `shm-<SHM ID>-aad-localsync-username` secret in the SHM Key Vault prepended with `<domain name>\`
+          + :information_source: For example, if the *domain name* is `testa.turingsafehaven.ac.uk` and the *username* is `testalocaladsync` then you would use `testa.turingsafehaven.ac.uk\testalocaladsync` here.
         + Password: use the `shm-<SHM ID>-aad-localsync-password` secret in the SHM Key Vault.
       + Click `OK`
       + **Troubleshooting:** if you get an error that the username/password is incorrect or that the domain/directory could not be found, try resetting the password for this user in the **Domain Controller** Active Directory to the value in the secret listed above.


### PR DESCRIPTION
### :orange_book:  Description
When installing Azure AD Connect, you are asked to enter the `localadsync` account username. This must be of the form `domain\username`. The Azure AD Connect installer has a tool tip to indicate this but the documentation instead says to enter the username (from a secret) without the domain.

This PR adjusts the documentation to say that a domain must be specified and includes an example. I'm not sure if there is a better, or canonical, example to use.

Check whether the following work or not and make sure that the documentation reflects that.
- :x: username
- ✅  domain\username
- ? username@domain

### :closed_umbrella: Related issues
Contributes to #825 