### PR TITLE
Fix bandersnatch failed downloads

### DIFF
--- a/deployment/safe_haven_management_environment/cloud_init/cloud-init-mirror-external-pypi.yaml
+++ b/deployment/safe_haven_management_environment/cloud_init/cloud-init-mirror-external-pypi.yaml
@@ -211,7 +211,7 @@ runcmd:
 
   # Install bandersnatch with pip
   - echo "*** Installing bandersnatch... ***"
-  - pip3 install bandersnatch
+  - pip3 install bandersnatch==4.2.0
   - echo "Using bandersnatch from '$(which bandersnatch)'"
 
   # Initialise whitelist if appropriate


### PR DESCRIPTION
### :orange_book:  Description
Pin version of bandersnatch as newer versions are not working

### :closed_umbrella: Related issues
Closes #844.

### :microscope: Tests
- Tested that this version works on newly-deployed tier-3 mirrors