### PR TITLE
Restrict TLS ciphersuites

### DIFF
--- a/deployment/secure_research_environment/remote/create_rds/scripts/Disable_Legacy_TLS_Remote.ps1
+++ b/deployment/secure_research_environment/remote/create_rds/scripts/Disable_Legacy_TLS_Remote.ps1
@@ -69,7 +69,7 @@ $recommended = $response.ciphersuites | ForEach-Object { $_.PSObject.Properties.
 $response = Invoke-RestMethod -Uri https://ciphersuite.info/api/cs/security/secure -ErrorAction Stop
 # Note that we overwrite gnutls_name in the Values hashtable with the `Name` property for later use
 $secure = $response.ciphersuites | ForEach-Object { $_.PSObject.Properties.Value.gnutls_name = $_.PSObject.Properties.Name; $_.PSObject.Properties.Value } `
-                                 | Where-Object { $_.kex_algorithm -ne "DHE" } `
+                                 | Where-Object { $_.kex_algorithm -eq "ECDHE" } `
                                  | Where-Object { $_.auth_algorithm -eq "RSA" } `
                                  | Where-Object { $_.enc_algorithm -like "AES * CBC" } `
                                  | Where-Object { $_.hash_algorithm -eq "SHA256" } `
@@ -110,6 +110,7 @@ foreach ($allowedCipher in $allowedCiphers) {
             # If it is not [ie. it has no CipherSuite entry] then immediately disable it.
             if ($((Get-TlsCipherSuite -Name $allowedCipher).CipherSuite) -eq 0) {
                 Disable-TlsCipherSuite -Name $allowedCipher
+                Write-Output " [x] Windows does not support the '$allowedCipher' suite."
             } else {
                 Write-Output " [o] Enabled '$allowedCipher' suite."
             }


### PR DESCRIPTION
### :orange_book:  Description
Restrict allowed ciphersuites to those recommended as secure plus one of the six fallbacks. 

**NB.** At least one of these fallbacks is needed to allow connections from the HTML5 RDS webclient.

| Name | Weaknesses |
| --- | --- |
| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256` | CBC |
| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA` | CBC, SHA1 |
| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` | CBC, SHA1 |
| `TLS_RSA_WITH_AES_256_CBC_SHA256` | CBC |
| `TLS_RSA_WITH_AES_128_CBC_SHA256` | CBC |
| `TLS_RSA_WITH_AES_128_CBC_SHA` | CBC, SHA1 |

We choose to use `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`

#### Additional ciphers
Testing additional ciphers mentioned in this ticket

| Name | Works? |
| --- | --- |
| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384` | :x: |
| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA256` | :x: |
| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384` | :x: |

### :closed_umbrella: Related issues
Closes #847

### :camera: SSL labs output

<img width="781" alt="Screen Shot 2020-10-14 at 15 40 40" src="https://user-images.githubusercontent.com/3502751/96004792-b7850080-0e33-11eb-9ae5-97bbc9d47f43.png">

<img width="945" alt="Screen Shot 2020-10-14 at 15 40 06" src="https://user-images.githubusercontent.com/3502751/96004859-c9ff3a00-0e33-11eb-9e31-6989f2cb889b.png">

### :microscope: Tests
- Tests are documented in #847
