### PR TITLE
Improve SRE deployment docs

### DIFF
--- a/docs/tutorial/deployment_tutorials/how-to-deploy-sre.md
+++ b/docs/tutorial/deployment_tutorials/how-to-deploy-sre.md
@@ -306,7 +306,7 @@ This will create a user in the local Active Directory on the SHM domain controll
 
 #### Ensure that your user account has MFA enabled
 
-Please ensure that your account is fully set-up (including MFA) as [detailed in the user guide](../user_guides/user_guide.md).
+Please ensure that your account is fully set-up (including MFA as [detailed in the user guide](../../how_to_guides/user_guides/user-guide.md#door-set-up-multi-factor-authentication)).
 In order to verify this switch to your custom Azure Active Directory in the Azure portal:
 
 + Go to `portal.azure.com` and click on your username in the top-right
@@ -321,7 +321,7 @@ You can now verify the following things
 + A licence must be assigned to the user.
   + Navigate to `Azure Active Directory` -> `Manage / Users` -> (user account) -> `Licenses` and verify that a license is assigned and the appropriate MFA service enabled.
 + MFA must be enabled for the user.
-  + The user must log into `aka.ms/mfasetup` and set up MFA as [detailed in the user guide](../user_guides/user_guide.md).
+  + The user must log into `aka.ms/mfasetup` and set up MFA as [detailed in the user guide](../../how_to_guides/user_guides/user-guide.md#door-set-up-multi-factor-authentication).
 
 ### :mountain_bicyclist: Test the RDS using a non-privileged user account
 


### PR DESCRIPTION
### :orange_book:  Description
This PR fixes some issues I found when deploying an SRE,
- Resource group names missing the SRE ID
- Dead links to other documentation

### :closed_umbrella: Related issues
Contributes to #825 

### :microscope: Tests
- Checked links point to the expected documents/sections
