### PR TITLE
Use mocking instead of redefining functions

### DIFF
--- a/tests/Run_Pester_Tests.ps1
+++ b/tests/Run_Pester_Tests.ps1
@@ -1,14 +1,20 @@
-Import-Module Pester -ErrorAction Stop
+# Set up a Pester run block with one parameter
+# --------------------------------------------
+$pesterBlock = {
+    param($RunPath)
+    Import-Module Pester -ErrorAction Stop
+
+    # Configuration with one parameter
+    $configuration = [PesterConfiguration]::Default
+    $configuration.Output.Verbosity = "Detailed"
+    $configuration.Run.Exit = $true
+    $configuration.Run.Path = $RunPath
+
+    # Run Pester
+    Invoke-Pester -Configuration $configuration
+}
 
 
-# Set Pester configuration
-# ------------------------
-$configuration = [PesterConfiguration]::Default
-$configuration.Output.Verbosity = "Detailed"
-$configuration.Run.Exit = $true
-$configuration.Run.Path = (Join-Path $PSScriptRoot "pester")
-
-
-# Run Pester tests
-# ----------------
-Invoke-Pester -Configuration $configuration
+# Run Pester tests in a fresh Powershell context
+# ----------------------------------------------
+Start-Job -ScriptBlock $pesterBlock -Arg (Join-Path $PSScriptRoot "pester") | Receive-Job -Wait -AutoRemoveJob

--- a/tests/pester/DataStructures.Tests.ps1
+++ b/tests/pester/DataStructures.Tests.ps1
@@ -1,10 +1,5 @@
 Import-Module $PSScriptRoot/../../deployment/common/DataStructures -Force -ErrorAction Stop
 
-
-# Redefine Write-Host to suppress output from log message functions
-function global:Write-Host() {}
-
-
 # Test ConvertTo-SortedHashtable
 Describe "Test ConvertTo-SortedHashtable" {
     It "Returns True if ordered hashtable is correctly sorted" {
@@ -68,6 +63,8 @@ Describe "Test Limit-StringLength MaximumLength" {
 }
 Describe "Test Limit-StringLength FailureIsFatal" {
     It "Should throw an exception since the string is too long" {
+        Mock Write-Host {} # we mock Write-Host here as we expect output from the exception
         { "abcdefghijklm" | Limit-StringLength -FailureIsFatal -MaximumLength 6 } | Should -Throw "'abcdefghijklm' has length 13 but must not exceed 6!"
+        Assert-MockCalled Write-Host -Exactly 1 -Scope It
     }
 }


### PR DESCRIPTION
### :orange_book:  Description
Update to the way that we run our Powershell tests. If we run them inside a subjob then mocking will work, which is a better solution than redefining functions.

### :microscope: Tests
- Tested that the tests run