### PR TITLE
Check whether nexus variable *exists* (and is a boolean) rather than …

### DIFF
--- a/deployment/common/Configuration.psm1
+++ b/deployment/common/Configuration.psm1
@@ -35,7 +35,7 @@ function Add-SreConfig {
             shortName        = "sre-$($sreConfigBase.sreId)".ToLower()
             subscriptionName = $sreConfigBase.subscriptionName
             tier             = $sreConfigBase.tier
-            nexus            = $sreConfigBase.nexus ? [bool]$sreConfigBase.nexus : $nexusDefault
+            nexus            = $sreConfigBase.nexus -is [bool] ? $sreConfigBase.nexus : $nexusDefault
         }
     }
     $config.sre.azureAdminGroupName = $sreConfigBase.azureAdminGroupName ? $sreConfigBase.azureAdminGroupName : $config.shm.azureAdminGroupName


### PR DESCRIPTION
### :orange_book:  Description
Fix the logic around the `nexus` config variable. Previously we were checking its value as a proxy for "does it exist" but this (of course) does not work for a boolean where `False` is a valid answer. Switch to explicitly checking whether this is a bool.

### :closed_umbrella: Related issues
Closes #871

### :microscope: Tests
- Tested that the configuration file is altered appropriately.
