### PR TITLE
Support multiple Posh-ACME versions

### DIFF
--- a/deployment/secure_research_environment/setup/Update_SRE_RDS_SSL_Certificate.ps1
+++ b/deployment/secure_research_environment/setup/Update_SRE_RDS_SSL_Certificate.ps1
@@ -164,6 +164,7 @@ if ($requestCertificate) {
         $testDomain = "dnstest.${BaseFqdn}"
         Add-LogMessage -Level Info "[ ] Attempting to create a DNS record for $testDomain..."
         if ($PublishCommandName -eq "Publish-DnsChallenge") {
+            Add-LogMessage -Level Warning "The version of the Posh-ACME module that you are using is <4.0.0. Support for this version will be dropped in future."
             $null = Publish-DnsChallenge $testDomain -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose
         } else {
             $null = Publish-Challenge $testDomain -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose
@@ -175,6 +176,7 @@ if ($requestCertificate) {
         }
         Add-LogMessage -Level Info "[ ] Attempting to delete a DNS record for $testDomain..."
         if ($UnpublishCommandName -eq "Unpublish-DnsChallenge") {
+            Add-LogMessage -Level Warning "The version of the Posh-ACME module that you are using is <4.0.0. Support for this version will be dropped in future."
             $null = Unpublish-DnsChallenge $testDomain -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose
         } else {
             $null = Unpublish-Challenge $testDomain -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose
@@ -189,6 +191,7 @@ if ($requestCertificate) {
         # -----------------------------------------------
         Add-LogMessage -Level Info "Sending the CSR to be signed by Let's Encrypt..."
         if ($PublishCommandName -eq "Publish-DnsChallenge") {
+            Add-LogMessage -Level Warning "The version of the Posh-ACME module that you are using is <4.0.0. Support for this version will be dropped in future."
             $null = Publish-DnsChallenge $BaseFqdn -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose
         } else {
             $null = Publish-Challenge $BaseFqdn -Account $PoshAcmeAccount -Token faketoken -Plugin Azure -PluginArgs $PoshAcmeParams -Verbose


### PR DESCRIPTION
### :orange_book: Description
As the `Publish-DNSChallenge` cmdlet in Posh-ACME module as of version 4.0.0 has been renamed `Publish-Challenge` we need to ensure that we check the name of the publish/unpublish DNS functions before calling them

### :arrow_heading_up: Squash-and-merge commit message
Ensure that we check the name of the publish/unpublish DNS functions before calling them.
Added a deprecation warning when using the old functions.

### :closed_umbrella: Related issues
Closes #909

### :microscope: Tests
- Are you able to test this @tomaslaz ?