### PR TITLE
Allow restart of VMs with VMStoppedToWarnSubscription warning

### DIFF
--- a/deployment/common/Deployments.psm1
+++ b/deployment/common/Deployments.psm1
@@ -149,7 +149,7 @@ function Confirm-VmStopped {
         [string]$ResourceGroupName
     )
     if ($vmStatuses -contains "ProvisioningState/failed/VMStoppedToWarnSubscription") {
-        Add-LogMessage -Level Warning "VM '$Name' has status: VMStoppedToWarnSubscription meaning stopped as a warning to non-paying subscription."
+        Add-LogMessage -Level Warning "VM '$Name' has status: VMStoppedToWarnSubscription meaning that it was automatically stopped when the subscription ran out of credit."
     }
     $vmStatuses = (Get-AzVM -Name $Name -ResourceGroupName $ResourceGroupName -Status).Statuses.Code
     return (($vmStatuses -contains "PowerState/stopped") -and (($vmStatuses -contains "ProvisioningState/succeeded") -or ($vmStatuses -contains "ProvisioningState/failed/VMStoppedToWarnSubscription")))


### PR DESCRIPTION
I noticed that after SREs were shut down automatically due to the subscription running out, I was unable to restart them and was getting the following warnings:

![Screenshot 2021-04-09 at 14 14 49](https://user-images.githubusercontent.com/5486164/114525360-f4447f80-9c3d-11eb-927c-bfcc7b00d45f.png)

The problem was that we weren't covering the case where the VM status contains `ProvisioningState/failed/VMStoppedToWarnSubscription` and would only allow a restart when it contained `ProvisioningState/succeeded`. I think this makes sense as something to allow, as this warning suggests there isn't any problem with the VM, just that Azure doesn't like it when you don't pay - here is what the VM looked like in the portal before I restarted it (note that the provisioning of disks succeeded):

![Screenshot 2021-04-13 at 09 51 02](https://user-images.githubusercontent.com/5486164/114525809-51403580-9c3e-11eb-9a30-961ba7ee48da.png)


### :arrow_heading_up: Squash-and-merge commit message
Allow restart of VMs with VMStoppedToWarnSubscription warning

### :microscope: Tests

I have re-run the manage VMs script after these changes and looks like all success (plus verified that the web client for this SRE is now up and running):

![Screenshot 2021-04-13 at 09 58 55](https://user-images.githubusercontent.com/5486164/114526429-e2afa780-9c3e-11eb-9c34-4179ff0c62b9.png)


