### PR TITLE
Update GitLab deb source 

### DIFF
--- a/deployment/secure_research_environment/cloud_init/cloud-init-gitlab.template.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-gitlab.template.yaml
@@ -49,7 +49,7 @@ apt:
   preserve_sources_list: true
   sources:
     gitlab.list:
-      source: "deb https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu bionic main"
+      source: "deb https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu focal main"
       keyid: F6403F6544A38863DAA0B6E03F01618A51312F3F  # GitLab B.V. (package repository signing key) <packages@gitlab.com>
 
 # Install necessary apt packages


### PR DESCRIPTION
This is a replacement for #1043 which was incorrectly merged into `main` instead of `develop`.