### PR TITLE
SSH to database virtual machines

### DIFF
--- a/deployment/secure_research_environment/network_rules/sre-nsg-rules-databases.json
+++ b/deployment/secure_research_environment/network_rules/sre-nsg-rules-databases.json
@@ -24,18 +24,6 @@
         "sourcePortRange": "*"
     },
     {
-        "name": "AllowMSSQLBrowserServiceInbound",
-        "access": "Allow",
-        "description": "Allow inbound connections to MSSQL Browser Service from compute subnet",
-        "destinationAddressPrefix": "{{sre.databases.mssql.ip}}",
-        "destinationPortRange": "1434",
-        "direction": "Inbound",
-        "priority": 2100,
-        "protocol": "UDP",
-        "sourceAddressPrefix": "{{sre.network.vnet.subnets.compute.cidr}}",
-        "sourcePortRange": "*"
-    },
-    {
         "name": "AllowMSSQLInbound",
         "access": "Allow",
         "description": "Allow inbound connections to MSSQL from compute subnet",
@@ -44,6 +32,18 @@
         "direction": "Inbound",
         "priority": 2100,
         "protocol": "TCP",
+        "sourceAddressPrefix": "{{sre.network.vnet.subnets.compute.cidr}}",
+        "sourcePortRange": "*"
+    },
+    {
+        "name": "AllowMSSQLBrowserServiceInbound",
+        "access": "Allow",
+        "description": "Allow inbound connections to MSSQL Browser Service from compute subnet",
+        "destinationAddressPrefix": "{{sre.databases.mssql.ip}}",
+        "destinationPortRange": "1434",
+        "direction": "Inbound",
+        "priority": 2110,
+        "protocol": "UDP",
         "sourceAddressPrefix": "{{sre.network.vnet.subnets.compute.cidr}}",
         "sourcePortRange": "*"
     },


### PR DESCRIPTION

### :arrow_heading_up: Summary
<!--
Please explain what your pull request does here.
-->

This PR tightens the NSG rules for the databases vnet. Inbound connections from the compute vnet are only allowed on the ports used by the PostgreSQL and MSSQL databases and only when the connection is to the IP address of the database using that port.

### :closed_umbrella: Related issues
<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Closes #1034 

