### PR TITLE
Block portal access for normal users

### DIFF
--- a/docs/tutorial/deployment_tutorials/how-to-deploy-shm.md
+++ b/docs/tutorial/deployment_tutorials/how-to-deploy-shm.md
@@ -15,8 +15,8 @@ These instructions will deploy a new Safe Haven Management Environment (SHM). Th
 + [:house_with_garden: 9. Deploy and configure domain controllers](#house_with_garden-9-deploy-and-configure-domain-controllers)
 + [:police_car: 10. Deploy and configure network policy server](#police_car-10-deploy-and-configure-network-policy-server)
 + [:closed_lock_with_key: 11. Require MFA for all users](#closed_lock_with_key-11-require-mfa-for-all-users)
-+ [:no_pedestrians: 12. Block portal access for normal users](#no_predestrians-12-block-portal-access-for-normal-users)
-+ [:package: 13. Deploy Python/R package repositories](#package-11-deploy-PythonR-package-repositories)
++ [:no_pedestrians: 12. Block portal access for normal users](#no_pedestrians-12-block-portal-access-for-normal-users)
++ [:package: 13. Deploy Python/R package repositories](#package-13-deploy-PythonR-package-repositories)
 + [:chart_with_upwards_trend: 14. Deploy logging](#chart_with_upwards_trend-14-deploy-logging)
 + [:fire_engine: 15. Deploy firewall](#fire_engine-15-deploy-firewall)
 


### PR DESCRIPTION
### :arrow_heading_up: Summary
<!--
Please explain what your pull request does here.
-->
This PR adds a step to the SHM deployment documentation. The step adds a policy which prevents users other than Global Administrators from using the Azure portal on the SHM tenant.

### :closed_umbrella: Related issues
<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Closes #1038 

#### :camera: Screenshots
<!--
Optionally include screenshots here.
-->

Screenshots showing a test user being refused connection to the Azure portal,

<img width="965" alt="Screen Shot 2021-11-15 at 15 11 38" src="https://user-images.githubusercontent.com/23616154/141807370-c4af31c7-0444-48e2-88da-4e95e8a66f9f.png">
<img width="965" alt="Screen Shot 2021-11-15 at 15 12 07" src="https://user-images.githubusercontent.com/23616154/141807378-d3ca7053-3bd8-4f0e-8a1d-441a024a51f4.png">


