### PR TITLE
Pin htmlproofer version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       language: ruby
       rvm: 3.0.3
       before_script: |
-        gem install html-proofer
+        gem install html-proofer -v 3.19.0
         pip install -r docs/build/requirements.txt
         ./docs/build/patches/patch_rinohtype.sh
       script: |


### PR DESCRIPTION
### :arrow_heading_up: Summary

Pin HTMLProofer to the last working version (v3.19.0)

### :closed_umbrella: Related issues

Closes #1148

### :microscope: Tests

- CI test running on this PR