### PR TITLE
Fix Windows VM sizes

### DIFF
--- a/deployment/common/Configuration.psm1
+++ b/deployment/common/Configuration.psm1
@@ -382,7 +382,7 @@ function Get-ShmConfig {
         safemodePasswordSecretName = "shm-$($shm.id)-vm-safemode-password-dc".ToLower()
         disks                      = [ordered]@{
             os = [ordered]@{
-                sizeGb = "64"
+                sizeGb = "128"
                 type   = "Standard_LRS"
             }
         }
@@ -411,7 +411,7 @@ function Get-ShmConfig {
         installationDirectory   = "C:\Installation"
         disks                   = [ordered]@{
             os = [ordered]@{
-                sizeGb = "64"
+                sizeGb = "128"
                 type   = "Standard_LRS"
             }
         }

--- a/tests/resources/shm_testa_full_config.json
+++ b/tests/resources/shm_testa_full_config.json
@@ -4,7 +4,7 @@
     "adDirectory": "C:\\ActiveDirectory",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },
@@ -279,7 +279,7 @@
     "adminPasswordSecretName": "shm-testa-vm-admin-password-nps",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },

--- a/tests/resources/shm_testb_full_config.json
+++ b/tests/resources/shm_testb_full_config.json
@@ -4,7 +4,7 @@
     "adDirectory": "C:\\ActiveDirectory",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },
@@ -279,7 +279,7 @@
     "adminPasswordSecretName": "shm-testb-vm-admin-password-nps",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },

--- a/tests/resources/shm_testc_full_config.json
+++ b/tests/resources/shm_testc_full_config.json
@@ -4,7 +4,7 @@
     "adDirectory": "C:\\ActiveDirectory",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },
@@ -279,7 +279,7 @@
     "adminPasswordSecretName": "shm-testc-vm-admin-password-nps",
     "disks": {
       "os": {
-        "sizeGb": "64",
+        "sizeGb": "128",
         "type": "Standard_LRS"
       }
     },

--- a/tests/resources/sre_testat1guac_full_config.json
+++ b/tests/resources/sre_testat1guac_full_config.json
@@ -5,7 +5,7 @@
       "adDirectory": "C:\\ActiveDirectory",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },
@@ -280,7 +280,7 @@
       "adminPasswordSecretName": "shm-testa-vm-admin-password-nps",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },

--- a/tests/resources/sre_testbt2guac_full_config.json
+++ b/tests/resources/sre_testbt2guac_full_config.json
@@ -5,7 +5,7 @@
       "adDirectory": "C:\\ActiveDirectory",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },
@@ -280,7 +280,7 @@
       "adminPasswordSecretName": "shm-testb-vm-admin-password-nps",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },

--- a/tests/resources/sre_testct3msrds_full_config.json
+++ b/tests/resources/sre_testct3msrds_full_config.json
@@ -5,7 +5,7 @@
       "adDirectory": "C:\\ActiveDirectory",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },
@@ -280,7 +280,7 @@
       "adminPasswordSecretName": "shm-testc-vm-admin-password-nps",
       "disks": {
         "os": {
-          "sizeGb": "64",
+          "sizeGb": "128",
           "type": "Standard_LRS"
         }
       },


### PR DESCRIPTION
### :arrow_heading_up: Summary

Revert Windows VM size change as 128 GB is the minimum

### :closed_umbrella: Related issues

None

### :microscope: Tests

None