### PR TITLE
Pin htmlproofer version in GitHub actionss

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -83,7 +83,7 @@ jobs:
           if [ "$FAILED" = "1" ]; then exit 1; fi
       - name: Install html-proofer
         shell: bash
-        run: gem install html-proofer
+        run: gem install html-proofer -v 3.19.0
       - name: Run HTML proofer
         shell: bash
         run: |


### PR DESCRIPTION
### :arrow_heading_up: Summary

Pin HTMLProofer to the last working version (v3.19.0)

### :closed_umbrella: Related issues

Missing fix from #1149. Closes #1148.

### :microscope: Tests

- CI test running on this PR