### PR TITLE
Fix QGIS repository key

### DIFF
--- a/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-1804.mustache.yaml
+++ b/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-1804.mustache.yaml
@@ -45,8 +45,8 @@ apt:
       keyid: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8  # PostgreSQL Debian Repository
 
     qgis.list:
-      source: "deb https://qgis.org/ubuntu bionic main"
-      keyid: 2445D6B254DAC452A498989E46B5721DBBD2996A  # QGIS Archive Automatic Signing Key (2021) <qgis-developer@lists.osgeo.org>
+      source: "deb https://ubuntu.qgis.org/ubuntu bionic main"
+      keyid: 2D7E3441A707FDB3E7059441D155B8E6A419C5BE  # QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
 
     rproject-updates.list:
       source: "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/"

--- a/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-2004.mustache.yaml
+++ b/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-2004.mustache.yaml
@@ -49,8 +49,8 @@ apt:
       keyid: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8  # PostgreSQL Debian Repository
 
     qgis.list:
-      source: "deb https://qgis.org/ubuntu focal main"
-      keyid: 2445D6B254DAC452A498989E46B5721DBBD2996A  # QGIS Archive Automatic Signing Key (2021) <qgis-developer@lists.osgeo.org>
+      source: "deb https://ubuntu.qgis.org/ubuntu focal main"
+      keyid: 2D7E3441A707FDB3E7059441D155B8E6A419C5BE  # QGIS Archive Automatic Signing Key (2022-2027) <qgis-developer@lists.osgeo.org>
 
     rproject-updates.list:
       source: "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/"


### PR DESCRIPTION
### :arrow_heading_up: Summary

Updated to 2022-27 QGIS signing key. See [QGIS](https://www.qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu) for more details.

### :closed_umbrella: Related issues

Closes #1187

### :microscope: Tests

Tested on a running SRE