### PR TITLE
Fix NVIDIA repository key

### DIFF
--- a/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-1804.mustache.yaml
+++ b/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-1804.mustache.yaml
@@ -34,7 +34,7 @@ apt:
 
     nvidia-cuda.list:
       source: "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /"
-      keyid: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80  # cudatools <cudatools@nvidia.com>
+      keyid: EB693B3035CD5710E231E123A4B469963BF863CC  # cudatools <cudatools@nvidia.com>
 
     nvidia-ml.list:
       source: "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"

--- a/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-2004.mustache.yaml
+++ b/deployment/secure_research_desktop/cloud_init/cloud-init-buildimage-ubuntu-2004.mustache.yaml
@@ -34,7 +34,7 @@ apt:
 
     nvidia-cuda.list:
       source: "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /"
-      keyid: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80  # cudatools <cudatools@nvidia.com>
+      keyid: EB693B3035CD5710E231E123A4B469963BF863CC  # cudatools <cudatools@nvidia.com>
 
     nvidia-ml-1804.list:
       source: "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"


### PR DESCRIPTION
### :arrow_heading_up: Summary

Update to 2022 NVIDIA signing key for CUDA repository. ML repository still uses the previous key.

### :closed_umbrella: Related issues

Closes #1192

### :microscope: Tests

Tested on a running SRE