### PR TITLE
Add Travis CI cache for Powershell modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,17 @@ jobs:
     - name: Test Powershell
       before_script:
         - sudo snap install powershell --classic
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Accounts"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Compute"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Dns"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.KeyVault"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Network"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.OperationalInsights"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.RecoveryServices"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Resources"
-        - pwsh -c "Install-Module -Force -Verbose -Name Az.Storage"
-        - pwsh -c "Install-Module -Force -Verbose -Name Pester"
-        - pwsh -c "Install-Module -Force -Verbose -Name PSScriptAnalyzer"
+        - pwsh -c "Install-Module -Verbose -Name Az.Accounts"
+        - pwsh -c "Install-Module -Verbose -Name Az.Compute"
+        - pwsh -c "Install-Module -Verbose -Name Az.Dns"
+        - pwsh -c "Install-Module -Verbose -Name Az.KeyVault"
+        - pwsh -c "Install-Module -Verbose -Name Az.Network"
+        - pwsh -c "Install-Module -Verbose -Name Az.OperationalInsights"
+        - pwsh -c "Install-Module -Verbose -Name Az.RecoveryServices"
+        - pwsh -c "Install-Module -Verbose -Name Az.Resources"
+        - pwsh -c "Install-Module -Verbose -Name Az.Storage"
+        - pwsh -c "Install-Module -Verbose -Name Pester"
+        - pwsh -c "Install-Module  -Verbose -Name PSScriptAnalyzer"
       script: pwsh -c "./tests/Run_Pester_Tests.ps1"
 
     - name: Lint JSON files


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] You have marked this pull request as a **draft** pull request if it is not ready to merge yet.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [ ] You have run the Powershell code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`. (N/A - Travis CI YAML change only)

### :arrow_heading_up: Summary

Gets Travis CI to cache `$HOME/.local/share/powershell/Modules/ ` to speed up the longest running element of the CI build, which is installing Powershell modules. It currently takes ~30 minutes to install modules to run a ~30 second Powershell test suite, and we do this even if no Powershell code has changed.

I'm following the approach at https://github.com/PowerShell/PowerShell/pull/6003/files, replacing the package install directory with `$HOME/.local/share/powershell/Modules/ ` after inspecting a Linux Travis CI build log to see where modules are getting installed.

I'm not sure we'll know if the latest version of powershell has changed, so I am not including a version environment variable, instead relying on the package versions being part of the full path and therefore when a newer version of a package is pulled, there will be a cache miss. (example full path is '/home/travis/.local/share/powershell/Modules/Az.Accounts/2.9.1`, with `$HOME` resolving to `/home/travis/` on Linux VMs on Travis CI.


### :closed_umbrella: Related issues

Closes #1262 

### :microscope: Tests

See [comment below](https://github.com/alan-turing-institute/data-safe-haven/pull/1263#issuecomment-1234710019).
