### PR TITLE
Update CoC to latest Turing Way template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,8 @@
 We value the participation of every member of our community and want to ensure that every contributor has an enjoyable and fulfilling experience.
 Accordingly, everyone who participates in the Data Safe Haven project is expected to show respect and courtesy to other community members at all times.
 
-Martin O'Reilly, as PI of this project, and all project members, are dedicated to a ***harassment-free experience for everyone***, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. **We do not tolerate harassment by and/or of members of our community in any form**.
+All project members, are dedicated to a ***harassment-free experience for everyone***, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion.
+**We do not tolerate harassment by and/or of members of our community in any form**.
 
 We are particularly motivated to support new and/or anxious collaborators, people who are looking to learn and develop their skills, and anyone who has experienced discrimination in the past.
 
@@ -38,9 +39,7 @@ All participants in our in-person events and online communications are expected 
 To make clear what is expected, everyone participating in activities associated with the Data Safe Haven project is required to conform to this Code of Conduct.
 This Code of Conduct applies to all spaces managed by the Data Safe Haven project including, but not limited to, in-person meetings and workshops, and communications online via GitHub and the Slack workspace.
 
-Dr. Martin O'Reilly and Dr. Kirstie Whitaker - are responsible for enforcing the Code of Conduct.
-They can be contacted by [moreilly@turing.ac.uk](mailto:moreilly@turing.ac.uk) [kwhitaker@turing.ac.uk](mailto:kwhitaker@turing.ac.uk) respectively.  Please note that Kirstie is on Maternity leave for the rest of 2022, therefore your emails will be handled by Martin.
-
+The [Code of Conduct Committee](#41-the-code-of-conduct-committee) are responsible for enforcing the Code of Conduct.
 Reports may be reviewed by other members of the core development team, unless there is a conflict of interest, and will be kept confidential.
 
 ## 2 Code of Conduct
@@ -96,19 +95,17 @@ If a participant engages in behaviour that violates this Code of Conduct, any me
 ### 2.4 Feedback
 
 This Code of Conduct is not intended as a static set of rules by which everyone must abide.
-Rather, you are invited to make suggestions for updates or clarifications by contacting Dr Martin O'Reilly at [moreilly@turing.ac.uk](mailto:moreilly@turing.ac.uk) or by making a pull request to this document on GitHub.
+Rather, you are invited to make suggestions for updates or clarifications by making a pull request to this document on GitHub.
 
 ## 3 Incident Reporting Guidelines
 
 ### 3.1 Contact points
 
-If you feel able to, please contact Martin O'Reilly by email at [moreilly@turing.ac.uk](mailto:moreilly@turing.ac.uk).
+If you feel able to, please contact one of the [Code of Conduct Committee](#41-the-code-of-conduct-committee) members by email.
 
 ### 3.2 Alternate contact points
 
-If you do not feel comfortable contacting Martin O'Reilly, please report an incident to Kirstie Whitaker by email at [kwhitaker@turing.ac.uk](mailto:kwhitaker@turing.ac.uk).
-
-Alternatively, if you would like to contact someone outside of the core development team, please contact [INSERT EXTERNAL CONTACT] by email at [[INSERT EXTERNAL CONTACT EMAIL]]().
+We are still looking for a contact outside of the core development team, please get in touch if you're interested.
 
 ### 3.3 What to do if someone is in physical danger
 
@@ -128,9 +125,9 @@ Enforcement of the Code of Conduct should be respectful and not include any hara
 
 The Code of Conduct committee is:
 
-- Martin O'Reilly: moreilly@turing.ac.uk
-- Kirstie Whitaker: kwhitaker@turing.ac.uk
-- [INSERT EXTERNAL CONTACT]: [INSERT EXTERNAL CONTACT EMAIL]
+- [Martin O'Reilly](https://www.turing.ac.uk/people/researchers/martin-oreilly) - [moreilly@turing.ac.uk](mailto:moreilly@turing.ac.uk) (**CoC lead**)
+- [Kirstie Whitaker](https://www.turing.ac.uk/people/researchers/kirstie-whitaker) - [kwhitaker@turing.ac.uk](mailto:kwhitaker@turing.ac.uk) (_currently on maternity leave_)
+- [Arielle Bennett](https://www.turing.ac.uk/people/programme-management/arielle-bennett) - [abennett@turing.ac.uk](mailto:abennett@turing.ac.uk) (_replacement contact until Kirstie returns_)
 
 As the community grows, we will seek to build a larger committee including members outside of the core development team.
 
@@ -142,7 +139,7 @@ This can include contacting law enforcement (or other local personnel) and speak
 If the act is ongoing, any community member may act immediately, before reaching consensus, to diffuse the situation.
 In ongoing situations, any member may at their discretion employ any of the tools available in this enforcement manual, including bans and blocks online, or removal from a physical space.
 
-In situations where an individual community member acts unilaterally, they must inform Martin O'Reilly as soon as possible, and report their actions for review within 24 hours.
+In situations where an individual community member acts unilaterally, they must inform [the Code of Conduct Committee](#41-the-code-of-conduct-committee) as soon as possible, and report their actions for review within 24 hours.
 
 ### 4.3 Less-Urgent Situations
 
@@ -165,8 +162,8 @@ In the event that a resolution can't be determined in that time, a member of the
 ### 4.4 Resolutions
 
 The CoC committee will seek to agree on a resolution by consensus of all members investigating the report in question.
-If the committee cannot reach consensus and deadlocks for over a week, Martin O'Reilly, as lead investigator of the Data Safe Haven project, will break the tie.
-If Martin O'Reilly is unable to take part in the discussion due to a conflict of interest, [INSERT EXTERNAL CONTACT], as an external member of the CoC committee, will make the decision.
+If the committee cannot reach consensus and deadlocks for over a week, the CoC lead, will break the tie.
+If the CoC lead is unable to take part in the discussion due to a conflict of interest, an external contact will be sought.
 
 Possible responses may include:
 
@@ -177,11 +174,11 @@ Possible responses may include:
 - A private in-person conversation between a member of the research team and the individual(s) involved.
   In this case, the person who has the conversation will provide a written summary for record keeping.
 - A private written reprimand from a member of the research team to the individual(s) involved.
-  In this case, the research team member will deliver that reprimand to the individual(s) over email, cc'ing Martin O'Reilly for record keeping.
+  In this case, the research team member will deliver that reprimand to the individual(s) over email, cc'ing [the Code of Conduct Committee](#41-the-code-of-conduct-committee) for record keeping.
 - A public announcement of an incident, ideally in the same venue that the violation occurred (such as on the listserv for a listserv violation; and GitHub for a GitHub violation).
   The committee may choose to publish this message elsewhere for posterity.
 - An imposed "time out" from online spaces.
-  Martin O'Reilly will communicate this "time out" to the individual(s) involved.
+  [The Code of Conduct Committee](#41-the-code-of-conduct-committee) will communicate this "time out" to the individual(s) involved.
 - A permanent or temporary ban from some or all Data Safe Haven project spaces (like on GitHub, Slack, online calls or in-person events).
   The research team will maintain records of all such bans so that they may be reviewed in the future, extended to a Code of Conduct safety team as it is built, or otherwise maintained.
   If a member of the community is removed from an event they will not be reimbursed for any part of the event that they miss.
@@ -192,7 +189,7 @@ However, the CoC committee is not required to act on this feedback.
 
 ### 4.5 Conflicts of Interest
 
-In the event of any conflict of interest such that Martin O'Reilly is not able to evaluate or enforce the reported violation, [INSERT EXTERNAL CONTACT] will take Kirstie's place.
+In the event of any conflict of interest such that one or more members of the [the Code of Conduct Committee](#41-the-code-of-conduct-committee) are unable to evaluate or enforce the reported violation, an external contact will take their place.
 
 ## 5 Acknowledgements
 


### PR DESCRIPTION
- [x] @edwardchalstrey1 to contact Turing HR on best way to proceed with a standard Turing-wide code of conduct

Read it [here](https://github.com/alan-turing-institute/data-safe-haven/blob/fix/code-of-conduct/CODE_OF_CONDUCT.md)

As per discussion, I have updated the CoC by:

- Removing duplicate paragraphs/sentences
- Copying the enforcement section from https://www.contributor-covenant.org/version/2/1/code_of_conduct/ 
- Removing any superfluous information
- Tidying the markdown to make it easier to read

Also importantly, I've added everyone tagged for review of this PR as a committee member - please let me know if you'd prefer that to not be the case.

I don't believe the code of conduct itself is substantively changed by these edits, but if you disagree with my edits/deletions, let me know.
