### PR TITLE
Modify powershell version requirements

### DIFF
--- a/deployment/CheckRequirements.ps1
+++ b/deployment/CheckRequirements.ps1
@@ -8,7 +8,8 @@ param (
 Import-Module $PSScriptRoot/common/Logging -Force -ErrorAction Stop
 
 # Requirements
-$PowershellVersionRequired = "7.0.0"
+$PowershellMinVersion = "7.0.0"
+$PowershellMaxVersion = "7.2.7"
 $ModuleVersionRequired = @{
     "Az.Accounts"                                  = @("ge", "2.9.0")
     "Az.Automation"                                = @("ge", "1.7.3")
@@ -37,10 +38,12 @@ if ($IncludeDev.IsPresent) {
 
 # Powershell version
 $PowershellVersion = (Get-Host | Select-Object Version).Version
-if ($PowershellVersion -ge $PowershellVersionRequired) {
+if ($PowershellVersion -gt $PowershellMaxVersion) {
+    Add-LogMessage -Level Fatal "Please downgrade Powershell to a minimum version of $PowershellMinVersion and a maximum of $PowershellMaxVersion (currently using $PowershellVersion)!"
+} elseif ($PowershellVersion -lt $PowershellMinVersion) {
+    Add-LogMessage -Level Fatal "Please upgrade Powershell to a minimum version of $PowershellMinVersion and a maximum of $PowershellMaxVersion (currently using $PowershellVersion)!"
+} else{
     Add-LogMessage -Level Success "Powershell version: $PowershellVersion"
-} else {
-    Add-LogMessage -Level Fatal "Please update your Powershell version to $PowershellVersionRequired or greater (currently using $PowershellVersion)!"
 }
 
 # Powershell modules

--- a/deployment/CheckRequirements.ps1
+++ b/deployment/CheckRequirements.ps1
@@ -42,7 +42,7 @@ if ($PowershellVersion -gt $PowershellMaxVersion) {
     Add-LogMessage -Level Fatal "Please downgrade Powershell to a minimum version of $PowershellMinVersion and a maximum of $PowershellMaxVersion (currently using $PowershellVersion)!"
 } elseif ($PowershellVersion -lt $PowershellMinVersion) {
     Add-LogMessage -Level Fatal "Please upgrade Powershell to a minimum version of $PowershellMinVersion and a maximum of $PowershellMaxVersion (currently using $PowershellVersion)!"
-} else{
+} else {
     Add-LogMessage -Level Success "Powershell version: $PowershellVersion"
 }
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [ ] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Checks if the available version of Powershell is >=7.0.0 and <=7.2.7, as there are currently some issues with Powershell 7.3.0.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Relates to #1332 but we should possibly keep the issue open until we can check whether an update to a more recent set of Az modules is a better solution.

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
