### PR TITLE
Use -ContextScope Process with Connect-MgGraph

### DIFF
--- a/deployment/administration/SHM_Add_AAD_Licences.ps1
+++ b/deployment/administration/SHM_Add_AAD_Licences.ps1
@@ -18,7 +18,7 @@ $config = Get-ShmConfig -shmId $shmId
 # --------------------------
 if (-not (Get-MgContext)) {
   Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
-  Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "Directory.ReadWrite.All" -ErrorAction Stop
+  Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "Directory.ReadWrite.All" -ErrorAction Stop -ContextScope Process
 }
 if (Get-MgContext) {
     Add-LogMessage -Level Success "Authenticated with Microsoft Graph"

--- a/deployment/administration/SRE_Teardown.ps1
+++ b/deployment/administration/SRE_Teardown.ps1
@@ -103,7 +103,7 @@ if ($config.sre.remoteDesktop.provider -eq "ApacheGuacamole") {
     } else {
         Add-LogMessage -Level Info "Ensuring that '$AzureAdApplicationName' is removed from Azure Active Directory..."
         if (-not (Get-MgContext)) {
-            Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop
+            Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop -ContextScope Process
         }
         try {
             Get-MgApplication -Filter "DisplayName eq '$AzureAdApplicationName'" | ForEach-Object { Remove-MgApplication -ApplicationId $_.Id }

--- a/deployment/safe_haven_management_environment/setup/Deploy_SHM.ps1
+++ b/deployment/safe_haven_management_environment/setup/Deploy_SHM.ps1
@@ -25,7 +25,7 @@ if (Get-AzContext) {
 # --------------------------
 if (Get-MgContext) { Disconnect-MgGraph | Out-Null } # force a refresh of the Microsoft Graph token before starting
 Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
-Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop | Out-Null
+Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop -ContextScope Process | Out-Null 
 if (Get-MgContext) {
     Add-LogMessage -Level Success "Authenticated with Microsoft Graph as $((Get-MgContext).Account)"
 } else {

--- a/deployment/safe_haven_management_environment/setup/Deploy_SHM.ps1
+++ b/deployment/safe_haven_management_environment/setup/Deploy_SHM.ps1
@@ -25,7 +25,7 @@ if (Get-AzContext) {
 # --------------------------
 if (Get-MgContext) { Disconnect-MgGraph | Out-Null } # force a refresh of the Microsoft Graph token before starting
 Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
-Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop -ContextScope Process | Out-Null 
+Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop -ContextScope Process | Out-Null
 if (Get-MgContext) {
     Add-LogMessage -Level Success "Authenticated with Microsoft Graph as $((Get-MgContext).Account)"
 } else {

--- a/deployment/safe_haven_management_environment/setup/Setup_SHM_AAD_Domain.ps1
+++ b/deployment/safe_haven_management_environment/setup/Setup_SHM_AAD_Domain.ps1
@@ -22,7 +22,7 @@ $null = Set-AzContext -Subscription $config.dns.subscriptionName -ErrorAction St
 # --------------------------
 if (-not (Get-MgContext)) {
     Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
-    Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop
+    Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop -ContextScope Process
     if (Get-MgContext) {
         Add-LogMessage -Level Success "Authenticated with Microsoft Graph"
     } else {

--- a/deployment/safe_haven_management_environment/setup/Setup_SHM_Key_Vault_And_Emergency_Admin.ps1
+++ b/deployment/safe_haven_management_environment/setup/Setup_SHM_Key_Vault_And_Emergency_Admin.ps1
@@ -24,7 +24,7 @@ $null = Set-AzContext -SubscriptionId $config.subscriptionName -ErrorAction Stop
 # --------------------------
 if (-not (Get-MgContext)) {
     Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
-    Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop
+    Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "User.ReadWrite.All", "UserAuthenticationMethod.ReadWrite.All", "Directory.AccessAsUser.All", "RoleManagement.ReadWrite.Directory" -ErrorAction Stop -ContextScope Process
     if (Get-MgContext) {
         Add-LogMessage -Level Success "Authenticated with Microsoft Graph"
     } else {

--- a/deployment/secure_research_environment/setup/Deploy_SRE.ps1
+++ b/deployment/secure_research_environment/setup/Deploy_SRE.ps1
@@ -45,9 +45,9 @@ $null = Set-AzContext -SubscriptionId $config.sre.subscriptionName -ErrorAction 
 if (Get-MgContext) { Disconnect-MgGraph | Out-Null } # force a refresh of the Microsoft Graph token before starting
 Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
 if ($UseDeviceAuthentication) {
-    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -UseDeviceAuthentication -ErrorAction Stop
+    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -UseDeviceAuthentication -ErrorAction Stop -ContextScope Process
 } else {
-    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop
+    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop -ContextScope Process
 }
 if (Get-MgContext) {
     Add-LogMessage -Level Success "Authenticated with Microsoft Graph as $((Get-MgContext).Account)"

--- a/deployment/secure_research_environment/setup/Setup_SRE_Guacamole_Servers.ps1
+++ b/deployment/secure_research_environment/setup/Setup_SRE_Guacamole_Servers.ps1
@@ -68,7 +68,7 @@ Add-LogMessage -Level Info "Ensuring that '$azureAdApplicationName' is registere
 if (Get-MgContext) {
     Add-LogMessage -Level Info "Already authenticated against Microsoft Graph"
 } else {
-    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop
+    Connect-MgGraph -TenantId $config.shm.azureAdTenantId -Scopes "Application.ReadWrite.All", "Policy.ReadWrite.ApplicationConfiguration" -ErrorAction Stop -ContextScope Process
 }
 try {
     $application = Get-MgApplication -Filter "DisplayName eq '$azureAdApplicationName'" -ErrorAction Stop


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Adds `-ContextScope Process` to all uses of `Connect-MgGraph`. Although 'Connect-MgGraph' seems to work fine on the Linux development container even without `-ContextScope Process`, subsequent attempts to use any Graph functions (e.g. `Get-MgApplication`) fail due to the way the authentication tokens are cached. `-ContextScope Process` caches them in memory instead, and then there are no further issues.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1332 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested several deployment steps involving Graph inside and outside container, all worked okay.