### PR TITLE
Bug fix with `-Upgrade` in `./Add_Single_SRD.ps1`

### DIFF
--- a/deployment/secure_research_environment/setup/Add_Single_SRD.ps1
+++ b/deployment/secure_research_environment/setup/Add_Single_SRD.ps1
@@ -80,7 +80,7 @@ if (($existingNic.VirtualMachine.Id) -and -not $Upgrade) {
 # -----------------------------------------------
 if ($Upgrade) {
     # Attempt to find exactly one existing virtual machine
-    $existingVm = Get-AzVM | Where-Object { $_.Name -match "$vmNamePrefix-\d-\d-\d{10}" }
+    $existingVm = Get-AzVM | Where-Object { $_.Name -match "$vmNamePrefix-\d{2}-\d{2}-\d{10}" }
     if (-not $existingVm) {
         Add-LogMessage -Level Fatal "No existing VM found to upgrade"
     } elseif ($existingVm.Length -ne 1) {


### PR DESCRIPTION
The code was unable to find an appropriately named and existing VM.

This is because `"00-00-" -match "\d-\d-"` returns false due to only looking for one digit.

Amended the VM string matching to use `"\d{2}-\d{2}-\d{10}"`.