### PR TITLE
Add script for automatically adding email authentication

### DIFF
--- a/deployment/administration/SHM_Add_AAD_User_Email_Authentication.ps1
+++ b/deployment/administration/SHM_Add_AAD_User_Email_Authentication.ps1
@@ -27,7 +27,7 @@ if (Get-MgContext) {
 # Find all users without with OnPremisesSyncEnabled=True, with Mail entries, who have not already got an authenticationemailmethod.
 # This indicates that they originated from a local AD.
 # ----------------------------------------------------------------------------------
-$users = Get-MgUser -Property Mail,DisplayName,OnPremisesSyncEnabled,UserPrincipalName | where { $_.OnPremisesSyncEnabled } | where { $_.Mail }
+$users = Get-MgUser -Property Mail, OnPremisesSyncEnabled, UserPrincipalName | where { $_.OnPremisesSyncEnabled } | where { $_.Mail }
 $users | ForEach-Object { 
     if (Get-MgUserAuthenticationEmailMethod -UserId $_.UserPrincipalName ) {
         Add-LogMessage -Level Info "User '$($_.UserPrincipalName)' already has an authentication email"

--- a/deployment/administration/SHM_Add_AAD_User_Email_Authentication.ps1
+++ b/deployment/administration/SHM_Add_AAD_User_Email_Authentication.ps1
@@ -1,0 +1,38 @@
+param(
+  [Parameter(Mandatory = $true, HelpMessage = "Enter SHM ID (e.g. use 'testa' for Turing Development Safe Haven A)")]
+  [string]$shmId
+)
+
+Import-Module Microsoft.Graph.Authentication -ErrorAction Stop
+Import-Module $PSScriptRoot/../common/Logging -Force -ErrorAction Stop
+
+
+# Get config
+# ----------
+$config = Get-ShmConfig -shmId $shmId
+
+
+# Connect to Microsoft Graph
+# --------------------------
+if (-not (Get-MgContext)) {
+  Add-LogMessage -Level Info "Attempting to authenticate with Microsoft Graph. Please sign in with an account with admin rights over the Azure Active Directory you plan to use."
+  Connect-MgGraph -TenantId $config.azureAdTenantId -Scopes "Directory.ReadWrite.All" -ErrorAction Stop
+}
+if (Get-MgContext) {
+    Add-LogMessage -Level Success "Authenticated with Microsoft Graph"
+} else {
+    Add-LogMessage -Level Fatal "Failed to authenticate with Microsoft Graph"
+}
+
+# Find all users without with OnPremisesSyncEnabled=True, with Mail entries, who have not already got an authenticationemailmethod.
+# This indicates that they originated from a local AD.
+# ----------------------------------------------------------------------------------
+$users = Get-MgUser -Property Mail,DisplayName,OnPremisesSyncEnabled,UserPrincipalName | where { $_.OnPremisesSyncEnabled } | where { $_.Mail }
+$users | ForEach-Object { 
+    if (Get-MgUserAuthenticationEmailMethod -UserId $_.UserPrincipalName ) {
+        Add-LogMessage -Level Info "User '$($_.UserPrincipalName)' already has an authentication email"
+    } else {
+        Add-LogMessage -Level Info "Adding authentication email '$($_.Mail)' to user '$($_.UserPrincipalName)'"
+        $null = New-MgUserAuthenticationEmailMethod -UserId $_.UserPrincipalName -EmailAddress $_.Mail
+    }
+}


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

Azure AD Connect adds phone numbers to authentication methods, but not emails. We do not always have phone numbers for users. The script `SHM_Add_AAD_User_Emaile_Authentication.ps1` adds an email authentication method for any users that: 1) have OnPremisesSyncEnabled, 2) have an email, 3) do not already have an email authentication method.
z



### :microscope: Tests

The script has been successfully used to add email authentication methods..
