### PR TITLE
Fix failing drive mounts

### DIFF
--- a/deployment/CheckRequirements.ps1
+++ b/deployment/CheckRequirements.ps1
@@ -9,7 +9,7 @@ Import-Module $PSScriptRoot/common/Logging -Force -ErrorAction Stop
 
 # Requirements
 $PowershellMinVersion = "7.0.0"
-$PowershellMaxVersion = "7.2.7"
+$PowershellMaxVersion = "7.2.8"
 $ModuleVersionRequired = @{
     "Az.Accounts"                                  = @("ge", "2.9.0")
     "Az.Automation"                                = @("ge", "1.7.3")

--- a/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
@@ -415,7 +415,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-backup"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
+        CACHE_SPACE_MB=$(echo "$(findmnt -nb -o size /) / 1024^2 / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o rw --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-backup.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 
@@ -426,7 +426,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-egress"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
+        CACHE_SPACE_MB=$(echo "$(findmnt -nb -o size /) / 1024^2 / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o rw --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-egress.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 
@@ -437,7 +437,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-ingress"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
+        CACHE_SPACE_MB=$(echo "$(findmnt -nb -o size /) / 1024^2 / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o ro --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-ingress.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 

--- a/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
@@ -415,7 +415,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-backup"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /mnt | awk '{print $2}' | sed 's/M//') / 2" | bc) # set the cache size to half the size of /mnt which scales with VM size
+        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o rw --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-backup.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 
@@ -426,7 +426,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-egress"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /mnt | awk '{print $2}' | sed 's/M//') / 2" | bc) # set the cache size to half the size of /mnt which scales with VM size
+        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o rw --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-egress.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 
@@ -437,7 +437,7 @@ write_files:
         BLOBFUSE_CACHE_DIR="/tmp/blobfuse-cache-ingress"
         rm -rf $BLOBFUSE_CACHE_DIR
         mkdir -p $BLOBFUSE_CACHE_DIR
-        CACHE_SPACE_MB=$(echo "$(df -BM | grep /mnt | awk '{print $2}' | sed 's/M//') / 2" | bc) # set the cache size to half the size of /mnt which scales with VM size
+        CACHE_SPACE_MB=$(echo "$(df -BM | grep /dev/root | awk '{print $2}' | sed 's/M//') / 50" | bc) # set the cache size to 2% of the OS disk size
         /usr/bin/blobfuse $1 -o ro --tmp-path=$BLOBFUSE_CACHE_DIR --cache-size-mb=$CACHE_SPACE_MB --no-symlinks=true --config-file=/opt/configuration/credentials-ingress.secret --log-level=LOG_DEBUG -o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other
       fi
 

--- a/deployment/secure_research_environment/remote/secure_research_desktop/scripts/check_drive_mounts.sh
+++ b/deployment/secure_research_environment/remote/secure_research_desktop/scripts/check_drive_mounts.sh
@@ -10,15 +10,16 @@ END="\033[0m"
 MOUNT_POINTS=("/data" "/home" "/scratch" "/shared" "/output")
 echo -e "${BLUE}Checking drives are mounted...${END}"
 for MOUNT_POINT in "${MOUNT_POINTS[@]}"; do
-    ls ${MOUNT_POINT}/* > /dev/null 2>&1
-    if [ "$(mount | grep $MOUNT_POINT)" ]; then
+    ls "${MOUNT_POINT}"/* > /dev/null 2>&1
+    if (mount | grep -q "$MOUNT_POINT"); then
         echo -e "${BLUE} [o] ${MOUNT_POINT} is mounted...${END}"
     else
         echo -e "${RED} [ ] ${MOUNT_POINT} not mounted. Attempting to mount...${END}"
-        if [ -e /etc/systemd/system/${MOUNT_POINT}.mount ]; then
-            systemctl start $(echo $MOUNT_POINT | sed 's|/||').mount
+        MOUNT_UNIT="$(echo "$MOUNT_POINT" | tr -d '/').mount"
+        if [ -e "/etc/systemd/system/${MOUNT_UNIT}" ]; then
+            systemctl start "${MOUNT_UNIT}"
         else
-            mount $MOUNT_POINT
+            mount "$MOUNT_POINT"
         fi
     fi
 done
@@ -26,10 +27,10 @@ sleep 30
 
 echo -e "${BLUE}Rechecking drives are mounted...${END}"
 for MOUNT_POINT in "${MOUNT_POINTS[@]}"; do
-    ls ${MOUNT_POINT}/* > /dev/null 2>&1
-    if [ "$(mount | grep $MOUNT_POINT)" ]; then
+    ls "${MOUNT_POINT}"/* > /dev/null 2>&1
+    if (mount | grep -q "$MOUNT_POINT"); then
         echo -e "${BLUE} [o] ${MOUNT_POINT} is mounted...${END}"
-        df -h  | grep $MOUNT_POINT
+        df -h  | grep "$MOUNT_POINT"
     else
         echo -e "${RED} [x] ${MOUNT_POINT} is not currently mounted...${END}"
     fi

--- a/deployment/secure_research_environment/remote/secure_research_desktop/scripts/check_drive_mounts.sh
+++ b/deployment/secure_research_environment/remote/secure_research_desktop/scripts/check_drive_mounts.sh
@@ -11,7 +11,7 @@ MOUNT_POINTS=("/data" "/home" "/scratch" "/shared" "/output")
 echo -e "${BLUE}Checking drives are mounted...${END}"
 for MOUNT_POINT in "${MOUNT_POINTS[@]}"; do
     ls "${MOUNT_POINT}"/* > /dev/null 2>&1
-    if (mount | grep -q "$MOUNT_POINT"); then
+    if (findmnt "$MOUNT_POINT" > /dev/null 2>&1); then
         echo -e "${BLUE} [o] ${MOUNT_POINT} is mounted...${END}"
     else
         echo -e "${RED} [ ] ${MOUNT_POINT} not mounted. Attempting to mount...${END}"
@@ -28,7 +28,7 @@ sleep 30
 echo -e "${BLUE}Rechecking drives are mounted...${END}"
 for MOUNT_POINT in "${MOUNT_POINTS[@]}"; do
     ls "${MOUNT_POINT}"/* > /dev/null 2>&1
-    if (mount | grep -q "$MOUNT_POINT"); then
+    if (findmnt "$MOUNT_POINT" > /dev/null 2>&1); then
         echo -e "${BLUE} [o] ${MOUNT_POINT} is mounted...${END}"
         df -h  | grep "$MOUNT_POINT"
     else


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

Update calculation of `blobfuse` cache size to be based on the OS disk size rather than the temporary `/mnt` disk. This is because in some situations `/mnt` will not be mounted resulting in an invalid `CACHE_SPACE_MB` calculation which causes the `blobfuse` mount unit to crash.

### :closed_umbrella: Related issues

Closes #1351.

### :microscope: Tests

Tested by @edwardchalstrey1 