### PR TITLE
Pulumi: Fix user list retrieval

### DIFF
--- a/data_safe_haven/commands/deploy_shm_command.py
+++ b/data_safe_haven/commands/deploy_shm_command.py
@@ -97,6 +97,10 @@ class DeploySHMCommand(LoggingMixin, Command):
                 config.shm.domain_controllers["ldap_searcher_password_secret"],
                 stack.secret("password-domain-ldap-searcher"),
             )
+            config.add_secret(
+                config.shm.domain_controllers["password_domain_admin"],
+                stack.secret("password-domain-admin"),
+            )
 
             # Upload config to blob storage
             config.upload()

--- a/data_safe_haven/commands/teardown_sre_command.py
+++ b/data_safe_haven/commands/teardown_sre_command.py
@@ -34,11 +34,15 @@ class TeardownSRECommand(LoggingMixin, Command):
                     f"Unable to load project settings. Please run this command from inside the project directory.\n{str(exc)}"
                 ) from exc
             config = Config(settings.name, settings.subscription_name)
-
             # Remove infrastructure deployed with Pulumi
             try:
                 stack = PulumiStack(config, "SRE", sre_name=self.argument("name"))
-                stack.teardown()
+                if stack.work_dir.exists():
+                    stack.teardown()
+                else:
+                    raise DataSafeHavenInputException(
+                        f"SRE %s not found - check the name is spelt correctly." % (self.argument("name"))
+                    )
             except Exception as exc:
                 raise DataSafeHavenInputException(
                     f"Unable to teardown Pulumi infrastructure.\n{str(exc)}"

--- a/data_safe_haven/commands/teardown_sre_command.py
+++ b/data_safe_haven/commands/teardown_sre_command.py
@@ -41,7 +41,7 @@ class TeardownSRECommand(LoggingMixin, Command):
                     stack.teardown()
                 else:
                     raise DataSafeHavenInputException(
-                        f"SRE %s not found - check the name is spelt correctly." % (self.argument("name"))
+                        f"SRE {self.argument('name')} not found - check the name is spelt correctly." 
                     )
             except Exception as exc:
                 raise DataSafeHavenInputException(

--- a/data_safe_haven/pulumi/components/shm_domain_controllers.py
+++ b/data_safe_haven/pulumi/components/shm_domain_controllers.py
@@ -184,7 +184,7 @@ class SHMDomainControllersComponent(ComponentResource):
             "ldap_root_dn": props.domain_root_dn,
             "ldap_search_username": props.username_domain_searcher,
             "ldap_searcher_password_secret": "password-domain-ldap-searcher",
-            "password_domain_admin": "password-domain-admin",
+            "password_domain_admin": "password-domain-vm-admin",
             "ldap_server_ip": primary_domain_controller.ip_address_private,
             "resource_group_name": resource_group.name,
             "vm_name": primary_domain_controller.vm_name,

--- a/data_safe_haven/pulumi/components/shm_domain_controllers.py
+++ b/data_safe_haven/pulumi/components/shm_domain_controllers.py
@@ -184,6 +184,7 @@ class SHMDomainControllersComponent(ComponentResource):
             "ldap_root_dn": props.domain_root_dn,
             "ldap_search_username": props.username_domain_searcher,
             "ldap_searcher_password_secret": "password-domain-ldap-searcher",
+            "password_domain_admin": "password-domain-admin",
             "ldap_server_ip": primary_domain_controller.ip_address_private,
             "resource_group_name": resource_group.name,
             "vm_name": primary_domain_controller.vm_name,

--- a/data_safe_haven/resources/active_directory/list_users.ps1
+++ b/data_safe_haven/resources/active_directory/list_users.ps1
@@ -1,6 +1,6 @@
 param (
     [Parameter(Mandatory = $false, HelpMessage = "SRE name")]
-    [string]$SREName = $null #this sets $SREName to an empty string, not to NULL
+    [string]$SREName = $null 
 )
 
 # Find SRE security group if an SRE name is specified

--- a/data_safe_haven/resources/active_directory/list_users.ps1
+++ b/data_safe_haven/resources/active_directory/list_users.ps1
@@ -1,16 +1,16 @@
 param (
     [Parameter(Mandatory = $false, HelpMessage = "SRE name")]
-    [string]$SREName = $null
+    [string]$SREName = $null #this sets $SREName to an empty string, not to NULL
 )
 
 # Find SRE security group if an SRE name is specified
-if ($null -ne $SREName) {
+if (![string]::IsNullOrEmpty($SREName)) {
     $SREGroup = Get-ADGroup -Filter "Name -like '*SRE $SREName*'" | Where-Object { $_.DistinguishedName -like '*Data Safe Haven Security Groups*' } | Select-Object -First 1
 }
 
 # Return all matching users
 $UserOuPath = (Get-ADObject -Filter * | Where-Object { $_.Name -eq "Data Safe Haven Research Users" }).DistinguishedName
 foreach ($User in $(Get-ADUser -Filter * -SearchBase $UserOuPath -Properties TelephoneNumber,Mail,MemberOf)) {
-    if (($null -ne $SREName) -and -not ($User.MemberOf.Contains($SREGroup.DistinguishedName))) { continue }
+    if ((![string]::IsNullOrEmpty($SREName)) -and -not ($User.MemberOf.Contains($SREGroup.DistinguishedName))) { continue }
     Write-Output "$($User.SamAccountName);$($User.GivenName);$($User.Surname);$($User.TelephoneNumber);$($User.Mail);$($User.UserPrincipalName)"
 }


### PR DESCRIPTION
### :arrow_heading_up: Summary

Fixes Powershell script `list_users.ps1` so that querying the user list correctly returns users from the domain controller, allowing them to be added to SREs etc.

Also adds domain controller password to backend vault

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1385
Also closes #1384 

