### PR TITLE
:arrow_up: Update caching in allowlists workflow

### DIFF
--- a/.github/workflows/build_allow_lists.yaml
+++ b/.github/workflows/build_allow_lists.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: environment_configs/package_lists/dependency-cache.json
           key: dependencies-${{ github.sha }}  # request a cache that does not yet exist


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

`actions/cache@v2` is no longer working. Here is a recent log:

```
  with:
    path: environment_configs/package_lists/dependency-cache.json
    key: dependencies-2d5ce740938d7a3ff28943ec04c497134ecc68eb
    restore-keys: dependencies-
  env:
    TIMEOUT_REACHED: 0
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Cache not found for input keys: dependencies-2d5ce740938d7a3ff28943ec04c497134ecc68eb, dependencies-
```

### :closed_umbrella: Related issues

n/a

### :microscope: Tests

n/a