### PR TITLE
Fix incorrect logic around automated PR creation

### DIFF
--- a/.github/workflows/build_allow_lists.yaml
+++ b/.github/workflows/build_allow_lists.yaml
@@ -52,9 +52,9 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Create pull request
-        if: ${{ (! env.TIMEOUT_REACHED) && (! env.ACT) }}
+        if: ${{ (env.TIMEOUT_REACHED == 0) && (! env.ACT) }}
         id: pull-request
-        uses: peter-evans/create-pull-request@dcd5fd746d53dd8de555c0f10bca6c35628be47a  # This commit corresponds to tag 3.12.0
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54  # This commit corresponds to tag 4.2.4
         with:
           commit-message: Update PyPI and CRAN allow lists
           committer: GitHub Actions <noreply@github.com>


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

- Update to v4.2.4 of create-pull-request
- Stop treating `TIMEOUT_REACHED` as a boolean

### :closed_umbrella: Related issues

n/a

### :microscope: Tests

Tested in CI