### PR TITLE
Better package name matching for Nexus 

### DIFF
--- a/deployment/safe_haven_management_environment/cloud_init/resources/configure_nexus.py
+++ b/deployment/safe_haven_management_environment/cloud_init/resources/configure_nexus.py
@@ -602,6 +602,7 @@ def get_allowlist(allowlist_path, is_cran):
 
     Args:
         allowlist_path: Path to the allowlist file
+        is_cran: True if the allowlist if for CRAN, False if it is for PyPI
 
     Returns:
         List of the package names specified in the file
@@ -609,7 +610,7 @@ def get_allowlist(allowlist_path, is_cran):
     allowlist = []
     with open(allowlist_path, "r") as allowlist_file:
         # Sanitise package names
-        # - convert to lower case if the package is on PyPi. Leave alone on CRAN to prevent issues with case-sensitivity
+        # - convert to lower case if the package is on PyPI. Leave alone on CRAN to prevent issues with case-sensitivity
         # - convert special characters to '-'
         # - remove any blank entries, which act as a wildcard that would allow any package
         special_characters = re.compile(r"[^0-9a-zA-Z]+")

--- a/deployment/safe_haven_management_environment/cloud_init/resources/configure_nexus.py
+++ b/deployment/safe_haven_management_environment/cloud_init/resources/configure_nexus.py
@@ -588,15 +588,15 @@ def get_allowlists(pypi_package_file, cran_package_file):
     cran_allowlist = []
 
     if pypi_package_file:
-        pypi_allowlist = get_allowlist(pypi_package_file)
+        pypi_allowlist = get_allowlist(pypi_package_file, False)
 
     if cran_package_file:
-        cran_allowlist = get_allowlist(cran_package_file)
+        cran_allowlist = get_allowlist(cran_package_file, True)
 
     return (pypi_allowlist, cran_allowlist)
 
 
-def get_allowlist(allowlist_path):
+def get_allowlist(allowlist_path, is_cran):
     """
     Read list of allowed packages from a file
 
@@ -609,12 +609,15 @@ def get_allowlist(allowlist_path):
     allowlist = []
     with open(allowlist_path, "r") as allowlist_file:
         # Sanitise package names
-        # - convert to lower case
+        # - convert to lower case if the package is on PyPi. Leave alone on CRAN to prevent issues with case-sensitivity
         # - convert special characters to '-'
         # - remove any blank entries, which act as a wildcard that would allow any package
         special_characters = re.compile(r"[^0-9a-zA-Z]+")
         for package_name in allowlist_file.readlines():
-            package_name = special_characters.sub("-", package_name.lower().strip())
+            if is_cran:
+                package_name = special_characters.sub("-", package_name.strip())
+            else:
+                package_name = special_characters.sub("-", package_name.lower().strip())
             if package_name:
                 allowlist.append(package_name)
     return allowlist
@@ -725,7 +728,7 @@ def recreate_privileges(tier, nexus_api, pypi_allowlist=[],
                 nexus_api,
                 name=f"cran-{package}",
                 description=f"allow access to {package} on CRAN",
-                expression=f'format == "r" and path=^"/src/contrib/{package}"',
+                expression=f'format == "r" and path=^"/src/contrib/{package}_"',
                 repo_type=_NEXUS_REPOSITORIES["cran_proxy"]["repo_type"],
                 repo=_NEXUS_REPOSITORIES["cran_proxy"]["name"]
             )


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [ ] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [ ] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Modifies how the `configure_nexus.py` script creates Nexus Content Selector search patterns, allowing CRAN packages to include capital letters and following the complete package name with `_` (e.g. `RPostgreSQL_`) to prevent overly permissive matching and installation of non-allow-listed packages.

Note that to perform the fix I had to teardown the existing proxy VM and redeploy it. The issues cannot be fixed by modifying the local copy of the `configure_nexus.py` script, as the important copy is on the docker container running Nexus on the VM. It's not clear to me how to modify that without redeploying the VM entirely (but it may be clear to someone else!).

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1445 
Closes #1439 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Packages with capital letters can now be installed correctly on Tier 3 VMs:
<img width="593" alt="Screenshot 2023-04-18 at 17 52 10" src="https://user-images.githubusercontent.com/5796417/232848910-b61ddae8-ab90-439f-9e2a-0317d7a0f740.png">

Packages that are not on the allowlist but that had names that would still match search patterns for other packages (e.g. `csvread`, which matched the pattern for `csv`) can no longer be installed and will correctly return a `403 Forbidden` code:
<img width="704" alt="Screenshot 2023-04-18 at 17 52 29" src="https://user-images.githubusercontent.com/5796417/232848864-4ad9d2b8-9f23-45e2-b0ed-62e2d86df5c0.png">


