### PR TITLE
Create users with no password expiry on AD

### DIFF
--- a/deployment/safe_haven_management_environment/desired_state_configuration/dc1Artifacts/CreateUsers.ps1
+++ b/deployment/safe_haven_management_environment/desired_state_configuration/dc1Artifacts/CreateUsers.ps1
@@ -26,7 +26,7 @@ Import-Csv $userFilePath | ForEach-Object {
         Path                 = "$userOuPath"
         Enabled              = $True
         AccountPassword      = (ConvertTo-SecureString $Password -AsPlainText -Force)
-        PasswordNeverExpires = $False
+        PasswordNeverExpires = $True
         Mobile               = $_.Mobile
         Email                = $_.SecondaryEmail
         Country              = "GB"


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [ ] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

Changes the flag `$PasswordNeverExpires` to `$True` in the `CreateUsers.ps1` script, so that users are created on the DC with the flag set, and preventing their password expiring on the local AD. This was causing log-in attempts on VMs to fail when the user's password was set over 90 days ago, despite still being able to log-in to the TRE in general.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1443

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

I have tested the modified code on the currently deployed blue SHM.