### PR TITLE
Force az login before reading Pulumi encryption key

### DIFF
--- a/data_safe_haven/config/config.py
+++ b/data_safe_haven/config/config.py
@@ -50,7 +50,7 @@ class Config(LoggingMixin, AzureMixin):
                 backend_storage_container_name,
             )
         # ... otherwise create a new DotMap
-        except (DataSafeHavenAzureException, ResourceNotFoundError):
+        except (DataSafeHavenAzureException, ResourceNotFoundError) as exc:
             self.warning(
                 f"Unable to load existing config file from '{backend_storage_account_name}'."
             )
@@ -163,7 +163,7 @@ class Config(LoggingMixin, AzureMixin):
             return str(keys[0].value)
         except Exception as exc:
             raise DataSafeHavenAzureException(
-                "Storage key could not be loaded."
+                f"Storage key could not be loaded.\n{str(exc)}"
             ) from exc
 
     def upload(self) -> None:

--- a/data_safe_haven/external/api/__init__.py
+++ b/data_safe_haven/external/api/__init__.py
@@ -1,7 +1,9 @@
 from .azure_api import AzureApi
+from .azure_cli import AzureCli
 from .graph_api import GraphApi
 
 __all__ = [
     "AzureApi",
+    "AzureCli",
     "GraphApi",
 ]

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -1,4 +1,4 @@
-"""Backend for a Data Safe Haven environment"""
+"""Interface to the Azure Python SDK"""
 # Standard library imports
 import time
 from contextlib import suppress

--- a/data_safe_haven/external/api/azure_cli.py
+++ b/data_safe_haven/external/api/azure_cli.py
@@ -1,0 +1,34 @@
+"""Interface to the Azure CLI"""
+# Standard library imports
+import subprocess
+from typing import Any
+
+# Local imports
+from data_safe_haven.exceptions import DataSafeHavenAzureException
+from data_safe_haven.mixins import LoggingMixin
+
+
+class AzureCli(LoggingMixin):
+    """Interface to the Azure CLI"""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+    def login(self) -> None:
+        """Force log in via the Azure CLI"""
+        try:
+            while True:
+                process = subprocess.run(["az", "account", "show"], capture_output=True)
+                if process.returncode == 0:
+                    break
+                self.info(
+                    "Please login in your web browser at https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize."
+                )
+                self.info(
+                    "If no web browser is available, please run `az login --use-device-code` in a command line window."
+                )
+                subprocess.run(["az", "login"], capture_output=True)
+        except FileNotFoundError as exc:
+            raise DataSafeHavenAzureException(
+                f"Please ensure that the Azure CLI is installed.\n{str(exc)}"
+            )

--- a/data_safe_haven/pulumi/components/sre_data.py
+++ b/data_safe_haven/pulumi/components/sre_data.py
@@ -266,7 +266,6 @@ class SREDataComponent(ComponentResource):
         # - Store the /data and /output folders here
         storage_account_securedata = storage.StorageAccount(
             f"{self._name}_storage_account_securedata",
-            # access_tier=storage.AccessTier.COOL,
             # Storage account names have a maximum of 24 characters
             account_name=alphanumeric(
                 f"{''.join(truncate_tokens(stack_name.split('-'), 14))}securedata{sha256hash(self._name)}"
@@ -284,7 +283,7 @@ class SREDataComponent(ComponentResource):
                     ),
                 ),
             ),
-            kind=storage.Kind.BLOCK_BLOB_STORAGE, #storage.Kind.STORAGE_V2,
+            kind=storage.Kind.BLOCK_BLOB_STORAGE,
             is_hns_enabled=True,
             location=props.location,
             network_rule_set=storage.NetworkRuleSetArgs(
@@ -307,7 +306,6 @@ class SREDataComponent(ComponentResource):
                 ],
             ),
             resource_group_name=resource_group.name,
-            #sku=storage.SkuArgs(name=storage.SkuName.STANDARD_ZRS),
             sku=storage.SkuArgs(name=storage.SkuName.PREMIUM_ZRS),
             opts=child_opts,
         )
@@ -352,7 +350,7 @@ class SREDataComponent(ComponentResource):
                 acl_user="rwx",
                 acl_group="rwx",
                 acl_other="rwx",
-                apply_default_permissions=False, # due to an Azure bug this also gives ownership of the fileshare to user 65533 (preventing use inside the SRE)
+                apply_default_permissions=False,  # due to an Azure bug this also gives ownership of the fileshare to user 65533 (preventing use inside the SRE)
                 container_name=storage_container_egress.name,
                 resource_group_name=resource_group.name,
                 storage_account_name=storage_account_securedata.name,
@@ -366,7 +364,7 @@ class SREDataComponent(ComponentResource):
                 acl_user="rwx",
                 acl_group="r-x",
                 acl_other="r-x",
-                apply_default_permissions=True, # ensure that the above permissions are also set on any newly created files (eg. with Azure Storage Explorer)
+                apply_default_permissions=True,  # ensure that the above permissions are also set on any newly created files (eg. with Azure Storage Explorer)
                 container_name=storage_container_ingress.name,
                 resource_group_name=resource_group.name,
                 storage_account_name=storage_account_securedata.name,


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the **develop branch**.
- [x] Your branch is up-to-date with the **develop branch** (you probably started your branch from `develop` but it may have changed since then).
- [x] If-and-only-if your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request and added '[WIP]' to the title.
- [x] If-and-only-if you have changed any Powershell code, you have run the code formatter. You can do this with `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>`.

### :arrow_heading_up: Summary

Force `az cli` login which is needed by Pulumi when accessing the encryption key from an Azure KeyVault.

### :closed_umbrella: Related issues

n/a

### :microscope: Tests

Tested locally