### PR TITLE
Change allowed FQDN for ADConnect endpoints

### DIFF
--- a/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
+++ b/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
@@ -29,7 +29,7 @@ $allowedFqdns = @($firewallRules.applicationRuleCollections | ForEach-Object { $
                 @(Get-PrivateDnsZones -ResourceGroupName $config.shm.network.vnet.rg -SubscriptionName $config.shm.subscriptionName | ForEach-Object { $_.Name })
 # List all unique FQDNs
 $allowedFqdns = $allowedFqdns |
-                Where-Object { $_ -notlike "g*.servicebus.windows.net" } | # Remove AzureADConnect password reset endpoints
+                Where-Object { $_ -notlike "*-sb.servicebus.windows.net" } | # Remove AzureADConnect password reset endpoints
                 Where-Object { $_ -notlike "pksproddatastore*.blob.core.windows.net" } | # Remove AzureAD operations endpoints
                 Sort-Object -Unique
 Add-LogMessage -Level Info "Restricted networks will be allowed to run DNS lookup on the following $($allowedFqdns.Count) FQDNs:"

--- a/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
+++ b/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
@@ -81,8 +81,8 @@ Add-LogMessage -Level Info "Looking for SRD with IP address '$vmIpAddress'..."
 if (-not $vmIpAddress) {
     Add-LogMessage -Level Fatal "No SRD found with IP address '$vmIpAddress'. Cannot run test to confirm external DNS resolution."
 } else {
-    # Match on both IP address and resource group
-    $vmName = @(Get-AzNetworkInterface | Where-Object { $_.IpConfigurations.PrivateIpAddress -eq $vmIpAddress -and $_.ResourceGroupName -eq $config.sre.srd.rg } | ForEach-Object { $_.VirtualMachine.Id.Split("/")[-1] })[0]
+    # Match on IP address within approriate SRE resource group
+    $vmName = @(Get-AzNetworkInterface -ResourceGroupName $config.sre.srd.rg | Where-Object { $_.IpConfigurations.PrivateIpAddress -eq $vmIpAddress } | ForEach-Object { $_.VirtualMachine.Id.Split("/")[-1] })[0]
     Add-LogMessage -Level Info "Testing external DNS resolution on VM '$vmName'..."
     $params = @{
         SHM_DOMAIN_FQDN   = $config.shm.domain.fqdn

--- a/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
+++ b/deployment/secure_research_environment/setup/Configure_External_DNS_Queries.ps1
@@ -81,7 +81,8 @@ Add-LogMessage -Level Info "Looking for SRD with IP address '$vmIpAddress'..."
 if (-not $vmIpAddress) {
     Add-LogMessage -Level Fatal "No SRD found with IP address '$vmIpAddress'. Cannot run test to confirm external DNS resolution."
 } else {
-    $vmName = @(Get-AzNetworkInterface | Where-Object { $_.IpConfigurations.PrivateIpAddress -eq $vmIpAddress } | ForEach-Object { $_.VirtualMachine.Id.Split("/")[-1] })[0]
+    # Match on both IP address and resource group
+    $vmName = @(Get-AzNetworkInterface | Where-Object { $_.IpConfigurations.PrivateIpAddress -eq $vmIpAddress -and $_.ResourceGroupName -eq $config.sre.srd.rg } | ForEach-Object { $_.VirtualMachine.Id.Split("/")[-1] })[0]
     Add-LogMessage -Level Info "Testing external DNS resolution on VM '$vmName'..."
     $params = @{
         SHM_DOMAIN_FQDN   = $config.shm.domain.fqdn


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [x] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [x] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Changes the FQDN that represents ADConnect endpoints used in a remote Powershell script. Previously, many individual endpoints were listed in the SHM firewall rules, which were captured by `g*.servicebus.windows.net`. The pattern needed to be changed.

In addition, when running the remote test scripts for external DNS queries, the script now only retrieves VM names from the appropriate resource group in the SHM/SRE, rather than finding any VM in the whole subscription with a matching IP address. 

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1503 
Closes #1507 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested on existing and new deployments of SREs 
