### PR TITLE
Add pip-tools to NON_IMPORTABLE_PACKAGES

### DIFF
--- a/tests/srd_smoke_tests/test_packages_installed_python.py
+++ b/tests/srd_smoke_tests/test_packages_installed_python.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+
 import pkg_resources
 
 versions = {
@@ -22,7 +23,10 @@ KNOWN_RESOURCE_ISSUES = [
 ]
 
 # For these packages we check for an executable as they are not importable
-NON_IMPORTABLE_PACKAGES = {"repro-catalogue": "catalogue", "pip-tools": "pip-compile"}
+NON_IMPORTABLE_PACKAGES = {
+    "pip-tools": "pip-compile",
+    "repro-catalogue": "catalogue",
+}
 
 # Some packages are imported using a different name than they `pip install` with
 IMPORTABLE_NAMES = {

--- a/tests/srd_smoke_tests/test_packages_installed_python.py
+++ b/tests/srd_smoke_tests/test_packages_installed_python.py
@@ -22,7 +22,7 @@ KNOWN_RESOURCE_ISSUES = [
 ]
 
 # For these packages we check for an executable as they are not importable
-NON_IMPORTABLE_PACKAGES = {"repro-catalogue": "catalogue"}
+NON_IMPORTABLE_PACKAGES = {"repro-catalogue": "catalogue", "pip-tools": "pip-compile"}
 
 # Some packages are imported using a different name than they `pip install` with
 IMPORTABLE_NAMES = {


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [ ] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [ ] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

This is needed so the smoke tests can run without trying to import `pip-tools` which is not a package

### :closed_umbrella: Related issues

https://github.com/alan-turing-institute/data-safe-haven-team/issues/21

### :microscope: Tests

I have made this change in the script within an SRE deployed from the `release-v4.0.4` branch and then run [smoke tests](https://alan-turing-institute.github.io/data-safe-haven/develop/deployment/deploy_sre_apache_guacamole.html#run-smoke-tests-on-srd) which now pass
