### PR TITLE
Allow az credential to get tokens for any tenant

### DIFF
--- a/data_safe_haven/external/interface/azure_authenticator.py
+++ b/data_safe_haven/external/interface/azure_authenticator.py
@@ -28,6 +28,7 @@ class AzureAuthenticator:
                 exclude_interactive_browser_credential=False,
                 exclude_shared_token_cache_credential=True,  # this requires multiple approvals per sign-in
                 exclude_visual_studio_code_credential=True,  # this often fails
+                additionally_allowed_tenants=["*"],
             )
         return self.credential_
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [x] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [x] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Ensures that the Azure credential object can fetch tokens from any credential.

See [here](https://github.com/Azure/azure-sdk-for-python/blob/b9979b23f3bfb815d2f5c21ca569e62a266cb092/sdk/identity/azure-identity/BREAKING_CHANGES.md#1110) for details.

I think multi-tenant authentication is necessary as in general the tenant holding the AAD is not necessarily the same as the tenant holding RGs and other resources.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->


Original error,

```console
❯ dsh init --admin-group 347c68cb-261f-4a3e-ac3e-6af860b5fec9 --location uksouth --subscription "Data Safe Haven Development" --name gems
2023-09-19 16:07:37 [    INFO] Reading project settings from                                  backend_settings.py:110
'/Users/jmadge/Library/Application Support/data_safe_haven/config.yaml'.
2023-09-19 16:07:37 [    INFO] Saved project settings to '/Users/jmadge/Library/Application   backend_settings.py:145
Support/data_safe_haven/config.yaml'.
2023-09-19 16:07:37 [    INFO] Reading project settings from                                  backend_settings.py:110
'/Users/jmadge/Library/Application Support/data_safe_haven/config.yaml'.
2023-09-19 16:07:54 [    INFO] Ensured that resource group shm-gems-rg-backend exists in uksouth.    azure_api.py:509
2023-09-19 16:07:55 [    INFO] Ensured that managed identity shm-gems-identity-reader-backend        azure_api.py:468
exists.
2023-09-19 16:07:55 [    INFO] Ensured that storage account shmgemsbackend exists.                   azure_api.py:552
2023-09-19 16:07:55 [    INFO] Ensured that storage container config exists.                         azure_api.py:587
2023-09-19 16:07:56 [    INFO] Ensured that storage container pulumi exists.                         azure_api.py:587
2023-09-19 16:07:56 [    INFO] Ensured that key vault shm-gems-kv-backend exists.                    azure_api.py:313
2023-09-19 16:07:57 [   ERROR] Could not initialise Data Safe Haven.                                        cli.py:94
2023-09-19 16:07:57 [   ERROR] Failed to create backend resources.                                          cli.py:94
2023-09-19 16:07:57 [   ERROR] Failed to create key pulumi-encryption-key.                                  cli.py:94
2023-09-19 16:07:57 [   ERROR] The current credential is not configured to acquire tokens for tenant        cli.py:94
<REMOVED GUID>. To enable acquiring tokens for this tenant add it to the
additionally_allowed_tenants when creating the credential, or add "*" to additionally_allowed_tenants to
allow acquiring tokens for any tenant.
```

Upon the change in this PR

```console
❯ dsh init --admin-group 347c68cb-261f-4a3e-ac3e-6af860b5fec9 --location uksouth --subscription "Data Safe Haven Development" --name gems
2023-09-19 16:33:18 [    INFO] Reading project settings from                                  backend_settings.py:110
'/Users/jmadge/Library/Application Support/data_safe_haven/config.yaml'.
2023-09-19 16:33:18 [    INFO] Saved project settings to '/Users/jmadge/Library/Application   backend_settings.py:145
Support/data_safe_haven/config.yaml'.
2023-09-19 16:33:18 [    INFO] Reading project settings from                                  backend_settings.py:110
'/Users/jmadge/Library/Application Support/data_safe_haven/config.yaml'.
2023-09-19 16:33:49 [    INFO] Ensured that resource group shm-gems-rg-backend exists in uksouth.    azure_api.py:509
2023-09-19 16:33:50 [    INFO] Ensured that managed identity shm-gems-identity-reader-backend        azure_api.py:468
exists.
2023-09-19 16:33:50 [    INFO] Ensured that storage account shmgemsbackend exists.                   azure_api.py:552
2023-09-19 16:33:51 [    INFO] Ensured that storage container config exists.                         azure_api.py:587
2023-09-19 16:33:51 [    INFO] Ensured that storage container pulumi exists.                         azure_api.py:587
2023-09-19 16:33:57 [    INFO] Ensured that key vault shm-gems-kv-backend exists.                    azure_api.py:313
2023-09-19 16:33:57 [    INFO] Ensured that key pulumi-encryption-key exists.                        azure_api.py:350
2023-09-19 16:34:01 [    INFO] Uploaded file config-gems.yaml to blob storage.                      azure_api.py:1192
```