### PR TITLE
Improve Pulumi error messages

### DIFF
--- a/.devcontainer/python/Dockerfile
+++ b/.devcontainer/python/Dockerfile
@@ -3,9 +3,8 @@ FROM python:${VARIANT}-buster
 
 # Set package versions
 ARG AZURE_CLI_VERSION="2.42.0"
-ARG PWSH_VERSION="7.2.6"
-ARG PULUMI_VERSION="3.45.0"
-ARG POETRY_VERSION="1.2.2"
+ARG PWSH_VERSION="7.3.6"
+ARG PULUMI_VERSION="3.80.0"
 
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
@@ -22,6 +21,7 @@ ARG TARGETARCH
 # Standard install method currently does not support ARM64
 # Use pip instead - https://github.com/Azure/azure-cli/issues/22875
 RUN pip3 install azure-cli==${AZURE_CLI_VERSION}
+RUN pip3 install hatch
 
 # Install Powershell
 # Pull different binaries from Github depending on system architecture
@@ -65,8 +65,3 @@ RUN pwsh -Command "& {Set-PSRepository -Name PSGallery -InstallationPolicy Trust
 
 # Set PATH for pulumi - pulumi installed as feature to work round installing as root
 ENV PATH=$PATH:/home/${USERNAME}/.pulumi/bin
-
-# Install poetry
-# Respects environment variables $POETRY_HOME and $POETRY_VERSION
-RUN curl -sSL https://install.python-poetry.org | python3 - \
-  && /home/${USERNAME}/.local/bin/poetry config virtualenvs.in-project true

--- a/.devcontainer/python/Dockerfile
+++ b/.devcontainer/python/Dockerfile
@@ -3,7 +3,6 @@ FROM python:${VARIANT}-buster
 
 # Set package versions
 ARG AZURE_CLI_VERSION="2.42.0"
-ARG PWSH_VERSION="7.3.6"
 ARG PULUMI_VERSION="3.80.0"
 
 RUN apt-get update \
@@ -23,21 +22,6 @@ ARG TARGETARCH
 RUN pip3 install azure-cli==${AZURE_CLI_VERSION}
 RUN pip3 install hatch
 
-# Install Powershell
-# Pull different binaries from Github depending on system architecture
-# The standard APT method currently only works for `amd64`
- RUN if [ "${TARGETARCH}" = "arm64" ]; \
-   then \
-     DEBARCH="arm64"; \
-   else \
-     DEBARCH="x86"; \
-   fi; \
-   curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-$DEBARCH.tar.gz \
-   && mkdir -p /opt/microsoft/powershell/7 \
-   && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
-   && chmod +x /opt/microsoft/powershell/7/pwsh \
-   && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
-
 # Create non-root user and give them sudo access
 ARG USERNAME=deploydsh
 ARG USER_UID=1000
@@ -55,13 +39,6 @@ USER $USERNAME
 # Install Sphinx dependencies
 COPY ./docs/requirements.txt /build/requirements.txt
 RUN pip3 install -r /build/requirements.txt
-
-# Install/check needed powershell modules
-COPY ./deployment/CheckRequirements.ps1 /build/CheckRequirements.ps1
-COPY ./deployment/common/Logging.psm1 /build/common/Logging.psm1
-RUN pwsh -Command "& {Set-PSRepository -Name PSGallery -InstallationPolicy Trusted}" \
-  && pwsh -File /build/CheckRequirements.ps1 -InstallMissing \
-  && sudo rm -rf /build/
 
 # Set PATH for pulumi - pulumi installed as feature to work round installing as root
 ENV PATH=$PATH:/home/${USERNAME}/.pulumi/bin

--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -2,14 +2,8 @@
 {
     "name": "Turing Data Safe Haven - Pulumi",
     "build": {
-        "context": "..",
-        "dockerfile": "Dockerfile",
-        "args": {
-            "POETRY_VERSION": "1.2.2",
-            "VARIANT": "3.10",
-            "PWSH_VERSION": "7.2.6",
-            "AZURE_CLI_VERSION": "2.42.0"
-        }
+        "context": "../..",
+        "dockerfile": "Dockerfile"
     },
     "settings": {
         "terminal.integrated.defaultProfile.linux": "bash"
@@ -24,7 +18,7 @@
     "remoteUser": "deploydsh",
     "features": {
         "ghcr.io/devcontainers-contrib/features/pulumi:1": {
-            "version": "3.45.0",
+            "version": "3.80.0",
             "bashCompletion": false
         }
     }

--- a/data_safe_haven/config/backend_settings.py
+++ b/data_safe_haven/config/backend_settings.py
@@ -88,7 +88,7 @@ class BackendSettings:
         if not self._name:
             msg = (
                 "Data Safe Haven deployment name not provided:"
-                " use '[bright_cyan]--deployment-name[/]' / '[green]-d[/]' to do so."
+                " use '[bright_cyan]--name[/]' / '[green]-n[/]' to do so."
             )
             raise DataSafeHavenParameterError(msg)
         return self._name

--- a/data_safe_haven/config/config.py
+++ b/data_safe_haven/config/config.py
@@ -12,7 +12,7 @@ import yaml
 from yaml.parser import ParserError
 
 from data_safe_haven import __version__
-from data_safe_haven.exceptions import DataSafeHavenAzureError, DataSafeHavenConfigError
+from data_safe_haven.exceptions import DataSafeHavenAzureError, DataSafeHavenConfigError, DataSafeHavenParameterError
 from data_safe_haven.external import AzureApi
 from data_safe_haven.functions import (
     alphanumeric,
@@ -352,7 +352,12 @@ class Config:
         self.sres: dict[str, ConfigSectionSRE] = defaultdict(ConfigSectionSRE)
         # Read backend settings
         settings = BackendSettings()
-        self.name = settings.name
+        # Check if backend exists and was loaded
+        try:
+            self.name = settings.name
+        except DataSafeHavenParameterError as exc:
+            msg = f"Data Safe Haven has not been initialised: run '[bright_cyan]dsh init[/]' before continuing."
+            raise DataSafeHavenConfigError(msg) from exc        
         self.subscription_name = settings.subscription_name
         self.azure.location = settings.location
         self.azure.admin_group_id = settings.admin_group_id

--- a/data_safe_haven/config/config.py
+++ b/data_safe_haven/config/config.py
@@ -356,8 +356,8 @@ class Config:
         try:
             self.name = settings.name
         except DataSafeHavenParameterError as exc:
-            msg = f"Data Safe Haven has not been initialised: run '[bright_cyan]dsh init[/]' before continuing."
-            raise DataSafeHavenConfigError(msg) from exc        
+            msg = "Data Safe Haven has not been initialised: run '[bright_cyan]dsh init[/]' before continuing."
+            raise DataSafeHavenConfigError(msg) from exc
         self.subscription_name = settings.subscription_name
         self.azure.location = settings.location
         self.azure.admin_group_id = settings.admin_group_id

--- a/data_safe_haven/config/config.py
+++ b/data_safe_haven/config/config.py
@@ -12,7 +12,11 @@ import yaml
 from yaml.parser import ParserError
 
 from data_safe_haven import __version__
-from data_safe_haven.exceptions import DataSafeHavenAzureError, DataSafeHavenConfigError, DataSafeHavenParameterError
+from data_safe_haven.exceptions import (
+    DataSafeHavenAzureError,
+    DataSafeHavenConfigError,
+    DataSafeHavenParameterError,
+)
 from data_safe_haven.external import AzureApi
 from data_safe_haven.functions import (
     alphanumeric,


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [ ] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [ ] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Fixes incorrect error messages for the deployment `name` argument passed to `dsh init`
Adds an error when the backend has not been initialised before attempting to run commands that rely on it (e.g. `dsh admin list-users`)

Note - this PR also updates the relevant .devcontainer to Pulumi version `3.80.0`

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1623 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested locally:
<img width="796" alt="better error" src="https://github.com/alan-turing-institute/data-safe-haven/assets/5796417/db015875-8b3d-40fb-9c83-4512accb1b12">


<img width="1012" alt="another better error" src="https://github.com/alan-turing-institute/data-safe-haven/assets/5796417/0a4e0081-df77-4318-bb1f-2dc6a446de65">

