### PR TITLE
Use memory for the /tmp directory 

### DIFF
--- a/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
@@ -592,6 +592,9 @@ runcmd:
   - systemctl enable data.automount
   - systemctl enable output.automount
 
+  - echo ">=== Configure tmpfs... ===<"
+  - echo "tmpfs /tmp tmpfs rw,nosuid,nodev,noexec" | tee -a /etc/fstab
+
   # List fstab and the volume mount order. Note that blobfuse mounts are not using fstab
   - echo ">=== Checking disk mounts... ===<"
   - grep -v -e '^[[:space:]]*$' /etc/fstab | sed 's|^|  /etc/fstab  |'

--- a/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
@@ -591,7 +591,7 @@ runcmd:
   - systemctl enable backup.automount
   - systemctl enable data.automount
   - systemctl enable output.automount
-  
+
   # Use tmpfs so tmp is in memory where possible rather than entirely on disk
   - echo ">=== Configure tmpfs... ===<"
   - echo "tmpfs /tmp tmpfs rw,nosuid,nodev,noexec" | tee -a /etc/fstab

--- a/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
+++ b/deployment/secure_research_environment/cloud_init/cloud-init-srd.mustache.yaml
@@ -591,7 +591,8 @@ runcmd:
   - systemctl enable backup.automount
   - systemctl enable data.automount
   - systemctl enable output.automount
-
+  
+  # Use tmpfs so tmp is in memory where possible rather than entirely on disk
   - echo ">=== Configure tmpfs... ===<"
   - echo "tmpfs /tmp tmpfs rw,nosuid,nodev,noexec" | tee -a /etc/fstab
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [ ] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [x] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Mounts `tmp` using `tmpfs`, so that it uses memory instead of disk space for temporary files. 

Currently uses 50% of RAM, and will use disk space if needed (e.g. files too big). Not sure if it will prevent disk lock-up or how to test that.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Relates to #1071. 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Deployed an SRD with `tmp` mounted on `tmpfs`