### PR TITLE
Correct file path for clamonacc service 

### DIFF
--- a/deployment/common/resources/clamav-clamonacc.service
+++ b/deployment/common/resources/clamav-clamonacc.service
@@ -7,7 +7,7 @@ After=clamav-daemon.service syslog.target network.target
 Type=simple
 User=root
 ExecStartPre=/bin/bash -c "while [ ! -S /var/run/clamav/clamd.ctl ]; do sleep 1; done"
-ExecStart=/usr/bin/clamonacc --foreground=true
+ExecStart=/usr/sbin/clamonacc --foreground=true
 Restart=on-failure
 RestartSec=30
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [ ] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [ ] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Fixes the file path for the ClamAV on-access scanning service, which is in `/usr/sbin/` rather than `/usr/bin`. The location of `clamdscan` was checked and is correct.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1722 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Deployed a PostgresSQL server after correcting the file path in the relevant file and confirmed that it was now running correctly. Note that this change will also apply to all other Linux VMs. I have checked several and confirmed that the `/usr/sbin/` location is correct.