### PR TITLE
Increase apt proxy server disk to 64 Gb

### DIFF
--- a/deployment/common/Configuration.psm1
+++ b/deployment/common/Configuration.psm1
@@ -343,7 +343,7 @@ function Get-ShmConfig {
                 adminPasswordSecretName = "shm-$($shm.id)-vm-admin-password-linux-update-server".ToLower()
                 disks                   = [ordered]@{
                     os = [ordered]@{
-                        sizeGb = "32"
+                        sizeGb = "64"
                         type   = $shm.diskTypeDefault
                     }
                 }

--- a/tests/resources/shm_blue_full_config.json
+++ b/tests/resources/shm_blue_full_config.json
@@ -758,7 +758,7 @@
         "adminPasswordSecretName": "shm-blue-vm-admin-password-linux-update-server",
         "disks": {
           "os": {
-            "sizeGb": "32",
+            "sizeGb": "64",
             "type": "Standard_LRS"
           }
         },

--- a/tests/resources/shm_green_full_config.json
+++ b/tests/resources/shm_green_full_config.json
@@ -758,7 +758,7 @@
         "adminPasswordSecretName": "shm-green-vm-admin-password-linux-update-server",
         "disks": {
           "os": {
-            "sizeGb": "32",
+            "sizeGb": "64",
             "type": "Standard_LRS"
           }
         },

--- a/tests/resources/sre_bluet1guac_full_config.json
+++ b/tests/resources/sre_bluet1guac_full_config.json
@@ -759,7 +759,7 @@
           "adminPasswordSecretName": "shm-blue-vm-admin-password-linux-update-server",
           "disks": {
             "os": {
-              "sizeGb": "32",
+              "sizeGb": "64",
               "type": "Standard_LRS"
             }
           },

--- a/tests/resources/sre_bluet3guac_full_config.json
+++ b/tests/resources/sre_bluet3guac_full_config.json
@@ -759,7 +759,7 @@
           "adminPasswordSecretName": "shm-blue-vm-admin-password-linux-update-server",
           "disks": {
             "os": {
-              "sizeGb": "32",
+              "sizeGb": "64",
               "type": "Standard_LRS"
             }
           },

--- a/tests/resources/sre_greent2guac_full_config.json
+++ b/tests/resources/sre_greent2guac_full_config.json
@@ -759,7 +759,7 @@
           "adminPasswordSecretName": "shm-green-vm-admin-password-linux-update-server",
           "disks": {
             "os": {
-              "sizeGb": "32",
+              "sizeGb": "64",
               "type": "Standard_LRS"
             }
           },


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [x] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).
- [ ] You have formatted your code using appropriate automated tools (for example `./tests/AutoFormat_Powershell.ps1 -TargetPath <path to file or directory>` for Powershell).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Increases the size of the Linux updates proxy server from 32Gb to 64 Gb. The default cache size for the proxy server is 40 Gb. TRESA found that the proxy server was full during the recent DSG, causing it to reject incoming connections and not download updates.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes alan-turing-institute/trusted-research#321  

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->


Redeployed with larger disk