### PR TITLE
Change AllowExternalAzureAutomationOperations to a network rule

### DIFF
--- a/data_safe_haven/infrastructure/stacks/shm/firewall.py
+++ b/data_safe_haven/infrastructure/stacks/shm/firewall.py
@@ -484,8 +484,8 @@ class SHMFirewallComponent(ComponentResource):
                             destination_ports=["53"],
                             name="AllowExternalDnsResolver",
                             protocols=[
-                                network.AzureFirewallNetworkRuleProtocol.UDP,
                                 network.AzureFirewallNetworkRuleProtocol.TCP,
+                                network.AzureFirewallNetworkRuleProtocol.UDP,
                             ],
                             source_addresses=[props.subnet_identity_servers_iprange],
                         ),
@@ -496,6 +496,17 @@ class SHMFirewallComponent(ComponentResource):
                     name=f"{stack_name}-all",
                     priority=1010,
                     rules=[
+                        network.AzureFirewallNetworkRuleArgs(
+                            description="Allow external Azure Automation requests",
+                            destination_addresses=["GuestAndHybridManagement"],
+                            destination_ports=["*"],
+                            name="AllowExternalAzureAutomationOperations",
+                            protocols=[
+                                network.AzureFirewallNetworkRuleProtocol.TCP,
+                                network.AzureFirewallNetworkRuleProtocol.UDP,
+                            ],
+                            source_addresses=["*"],
+                        ),
                         network.AzureFirewallNetworkRuleArgs(
                             description="Allow external NTP requests",
                             destination_addresses=ntp_ip_addresses,

--- a/data_safe_haven/infrastructure/stacks/shm/firewall.py
+++ b/data_safe_haven/infrastructure/stacks/shm/firewall.py
@@ -313,8 +313,10 @@ class SHMFirewallComponent(ComponentResource):
                             description="Allow external Azure Automation requests",
                             name="AllowExternalAzureAutomationOperations",
                             protocols=[
-                                network.AzureFirewallNetworkRuleProtocol.TCP,
-                                network.AzureFirewallNetworkRuleProtocol.UDP,
+                                network.AzureFirewallApplicationRuleProtocolArgs(
+                                    port=443,
+                                    protocol_type="Https",
+                                )
                             ],
                             source_addresses=["*"],
                             target_fqdns=[


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).
- [x] You have marked this pull request as a **draft** and added `'[WIP]'` to the title if needed (if you're not yet ready to merge).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
`AllowExternalAzureAutomationOperations` needs an application rule to filter on protocol/type and a network rule to filter on traffic type.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Fix small bug from #1781

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
Not tested