### PR TITLE
Add pulumi tests

### DIFF
--- a/data_safe_haven/infrastructure/common/transformations.py
+++ b/data_safe_haven/infrastructure/common/transformations.py
@@ -13,7 +13,7 @@ def get_address_prefixes_from_subnet(subnet: network.GetSubnetResult) -> list[st
         return [str(p) for p in address_prefixes]
     if address_prefix := subnet.address_prefix:
         return [address_prefix]
-    msg = f"Subnet '{subnet.name}' has no address prefix."
+    msg = f"Subnet '{subnet}' has no address prefix."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -28,7 +28,7 @@ def get_id_from_rg(rg: resources.ResourceGroup) -> Output[str]:
     """Get the ID of a resource group"""
     if isinstance(rg.id, Output):
         return rg.id
-    msg = f"Resource group '{rg.name}' has no ID."
+    msg = f"Resource group '{rg}' has no ID."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -36,7 +36,7 @@ def get_id_from_subnet(subnet: network.GetSubnetResult) -> str:
     """Get the ID of a subnet"""
     if id_ := subnet.id:
         return str(id_)
-    msg = f"Subnet '{subnet.name}' has no ID."
+    msg = f"Subnet '{subnet}' has no ID."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -44,7 +44,7 @@ def get_id_from_vnet(vnet: network.VirtualNetwork) -> Output[str]:
     """Get the ID of a virtual network"""
     if isinstance(vnet.id, Output):
         return vnet.id
-    msg = f"Virtual network '{vnet.name}' has no ID."
+    msg = f"Virtual network '{vnet}' has no ID."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -77,7 +77,7 @@ def get_ip_addresses_from_private_endpoint(
                 else []
             )
         )
-    msg = f"Private endpoint '{endpoint.name}' has no IP addresses."
+    msg = f"Private endpoint '{endpoint}' has no IP addresses."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -85,7 +85,7 @@ def get_name_from_rg(rg: resources.ResourceGroup) -> Output[str]:
     """Get the name of a resource group"""
     if isinstance(rg.name, Output):
         return rg.name.apply(str)
-    msg = f"Resource group '{rg.id}' has no name."
+    msg = f"Resource group '{rg}' has no name."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -93,7 +93,7 @@ def get_name_from_subnet(subnet: network.GetSubnetResult) -> str:
     """Get the name of a subnet"""
     if name := subnet.name:
         return str(name)
-    msg = f"Subnet '{subnet.id}' has no name."
+    msg = f"Subnet '{subnet}' has no name."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -101,7 +101,7 @@ def get_name_from_vnet(vnet: network.VirtualNetwork) -> Output[str]:
     """Get the name of a virtual network"""
     if isinstance(vnet.name, Output):
         return vnet.name.apply(str)
-    msg = f"Virtual network '{vnet.id}' has no name."
+    msg = f"Virtual network '{vnet}' has no name."
     raise DataSafeHavenPulumiError(msg)
 
 
@@ -109,5 +109,5 @@ def get_subscription_id_from_rg(rg: resources.ResourceGroup) -> Output[str]:
     """Get the ID of a subscription from a resource group"""
     if isinstance(rg.id, Output):
         return rg.id.apply(lambda id_: id_.split("/resourceGroups/")[0])
-    msg = f"Could not extract subscription ID from resource group '{rg.name}'."
+    msg = f"Could not extract subscription ID from resource group '{rg}'."
     raise DataSafeHavenPulumiError(msg)

--- a/data_safe_haven/infrastructure/programs/sre/application_gateway.py
+++ b/data_safe_haven/infrastructure/programs/sre/application_gateway.py
@@ -90,7 +90,7 @@ class SREApplicationGatewayComponent(ComponentResource):
 
         # Define application gateway
         application_gateway_name = f"{stack_name}-ag-entrypoint"
-        network.ApplicationGateway(
+        self.application_gateway = network.ApplicationGateway(
             f"{self._name}_application_gateway",
             application_gateway_name=application_gateway_name,
             backend_address_pools=[

--- a/tests/infrastructure/programs/resource_assertions.py
+++ b/tests/infrastructure/programs/resource_assertions.py
@@ -7,7 +7,7 @@ def assert_equal(target, source):
     try:
         assert source == target
     except AssertionError as exc:
-        msg = f"'{source}' and '{target}' are not equal."
+        msg = f"'{source}' {type(source)} and '{target}' {type(target)} are not equal."
         raise ValueError(msg) from exc
 
 

--- a/tests/infrastructure/programs/resource_assertions.py
+++ b/tests/infrastructure/programs/resource_assertions.py
@@ -1,0 +1,17 @@
+"""Functions for testing Pulumi resources inside an apply loop"""
+
+import json
+
+
+def assert_equal(target, source):
+    try:
+        assert source == target
+    except AssertionError as exc:
+        msg = f"'{source}' and '{target}' are not equal."
+        raise ValueError(msg) from exc
+
+
+def assert_equal_json(target, source):
+    json_source = json.dumps(source, sort_keys=True)
+    json_target = json.dumps(target, sort_keys=True)
+    assert_equal(json_source, json_target)

--- a/tests/infrastructure/programs/sre/conftest.py
+++ b/tests/infrastructure/programs/sre/conftest.py
@@ -1,0 +1,77 @@
+from pulumi_azure_native import managedidentity, network, resources
+from pytest import fixture
+
+from data_safe_haven.infrastructure.common import SREIpRanges
+
+
+#
+# Constants
+#
+@fixture
+def location() -> str:
+    return "uksouth"
+
+
+@fixture
+def resource_group_name() -> str:
+    return "rg-example"
+
+
+@fixture
+def resource_group(location, resource_group_name) -> resources.ResourceGroup:
+    return resources.ResourceGroup(
+        "resource_group",
+        location=location,
+        resource_group_name=resource_group_name,
+    )
+
+
+@fixture
+def sre_fqdn() -> str:
+    return "sre.example.com"
+
+
+@fixture
+def sre_index() -> int:
+    return 1
+
+
+@fixture
+def stack_name() -> str:
+    return "stack-example"
+
+
+@fixture
+def tags() -> dict[str, str]:
+    return {"key": "value"}
+
+
+#
+# Pulumi resources
+#
+@fixture
+def identity_key_vault_reader(
+    location, resource_group_name, stack_name
+) -> managedidentity.UserAssignedIdentity:
+    return managedidentity.UserAssignedIdentity(
+        "identity_key_vault_reader",
+        location=location,
+        resource_group_name=resource_group_name,
+        resource_name_=f"{stack_name}-id-key-vault-reader",
+    )
+
+
+@fixture
+def subnet_application_gateway(sre_index) -> network.GetSubnetResult:
+    return network.GetSubnetResult(
+        address_prefix=str(SREIpRanges(sre_index).application_gateway),
+        id="subnet_application_gateway_id",
+    )
+
+
+@fixture
+def subnet_guacamole_containers(sre_index) -> network.GetSubnetResult:
+    return network.GetSubnetResult(
+        address_prefix=str(SREIpRanges(sre_index).guacamole_containers),
+        id="subnet_guacamole_containers_id",
+    )

--- a/tests/infrastructure/programs/sre/test_application_gateway.py
+++ b/tests/infrastructure/programs/sre/test_application_gateway.py
@@ -44,6 +44,52 @@ def application_gateway_component(
     )
 
 
+class TestSREApplicationGatewayProps:
+    @pulumi.runtime.test
+    def test_props(self, application_gateway_props: SREApplicationGatewayProps):
+        assert isinstance(application_gateway_props, SREApplicationGatewayProps)
+
+    @pulumi.runtime.test
+    def test_props_key_vault_certificate_id(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        pulumi.Output.from_input(
+            application_gateway_props.key_vault_certificate_id
+        ).apply(partial(assert_equal, "key_vault_certificate_id"))
+
+    @pulumi.runtime.test
+    def test_props_resource_group_name(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        application_gateway_props.resource_group_name.apply(
+            partial(assert_equal, "None")
+        )
+
+    @pulumi.runtime.test
+    def test_props_sre_fqdn(
+        self, application_gateway_props: SREApplicationGatewayProps, sre_fqdn
+    ):
+        pulumi.Output.from_input(application_gateway_props.sre_fqdn).apply(
+            partial(assert_equal, sre_fqdn)
+        )
+
+    @pulumi.runtime.test
+    def test_props_subnet_application_gateway_id(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        application_gateway_props.subnet_application_gateway_id.apply(
+            partial(assert_equal, "subnet_application_gateway_id")
+        )
+
+    @pulumi.runtime.test
+    def test_props_subnet_guacamole_containers_ip_addresses(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        application_gateway_props.subnet_guacamole_containers_ip_addresses.apply(
+            partial(assert_equal, ["10.1.1.28", "10.1.1.29", "10.1.1.30"])
+        )
+
+
 class TestSREApplicationGatewayComponent:
     @pulumi.runtime.test
     def test_application_gateway(

--- a/tests/infrastructure/programs/sre/test_application_gateway.py
+++ b/tests/infrastructure/programs/sre/test_application_gateway.py
@@ -55,14 +55,27 @@ class TestSREApplicationGatewayProps:
     ):
         pulumi.Output.from_input(
             application_gateway_props.key_vault_certificate_id
-        ).apply(partial(assert_equal, "key_vault_certificate_id"))
+        ).apply(
+            partial(assert_equal, "key_vault_certificate_id"),
+            run_with_unknowns=True,
+        )
+
+    @pulumi.runtime.test
+    def test_props_resource_group_id(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        application_gateway_props.resource_group_id.apply(
+            partial(assert_equal, pulumi.UNKNOWN),
+            run_with_unknowns=True,
+        )
 
     @pulumi.runtime.test
     def test_props_resource_group_name(
         self, application_gateway_props: SREApplicationGatewayProps
     ):
         application_gateway_props.resource_group_name.apply(
-            partial(assert_equal, "None")
+            partial(assert_equal, "None"),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -70,7 +83,8 @@ class TestSREApplicationGatewayProps:
         self, application_gateway_props: SREApplicationGatewayProps, sre_fqdn
     ):
         pulumi.Output.from_input(application_gateway_props.sre_fqdn).apply(
-            partial(assert_equal, sre_fqdn)
+            partial(assert_equal, sre_fqdn),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -78,7 +92,8 @@ class TestSREApplicationGatewayProps:
         self, application_gateway_props: SREApplicationGatewayProps
     ):
         application_gateway_props.subnet_application_gateway_id.apply(
-            partial(assert_equal, "subnet_application_gateway_id")
+            partial(assert_equal, "subnet_application_gateway_id"),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -86,7 +101,17 @@ class TestSREApplicationGatewayProps:
         self, application_gateway_props: SREApplicationGatewayProps
     ):
         application_gateway_props.subnet_guacamole_containers_ip_addresses.apply(
-            partial(assert_equal, ["10.1.1.28", "10.1.1.29", "10.1.1.30"])
+            partial(assert_equal, ["10.1.1.28", "10.1.1.29", "10.1.1.30"]),
+            run_with_unknowns=True,
+        )
+
+    @pulumi.runtime.test
+    def test_props_user_assigned_identities(
+        self, application_gateway_props: SREApplicationGatewayProps
+    ):
+        application_gateway_props.user_assigned_identities.apply(
+            partial(assert_equal, pulumi.UNKNOWN),
+            run_with_unknowns=True,
         )
 
 
@@ -105,7 +130,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.authentication_certificates.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -113,7 +139,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.autoscale_configuration.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -137,7 +164,8 @@ class TestSREApplicationGatewayComponent:
                         "name": "appGatewayBackendGuacamole",
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -159,7 +187,8 @@ class TestSREApplicationGatewayComponent:
                         "request_timeout": 30,
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -167,7 +196,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.backend_settings_collection.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -175,7 +205,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.custom_error_configurations.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -183,7 +214,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.default_predefined_ssl_policy.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -191,7 +223,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.enable_fips.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -199,7 +232,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.enable_http2.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -207,7 +241,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.etag.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -215,7 +250,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.firewall_policy.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -223,7 +259,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.force_firewall_policy_association.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -243,7 +280,8 @@ class TestSREApplicationGatewayComponent:
                         "public_ip_address": {"id": None},
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -269,7 +307,8 @@ class TestSREApplicationGatewayComponent:
                         "port": 443,
                     },
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -288,7 +327,8 @@ class TestSREApplicationGatewayComponent:
                         "subnet": {"id": "subnet_application_gateway_id"},
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -296,7 +336,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.global_configuration.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -329,7 +370,8 @@ class TestSREApplicationGatewayComponent:
                         "ssl_certificate": {"id": None},
                     },
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -340,7 +382,8 @@ class TestSREApplicationGatewayComponent:
             partial(
                 assert_equal_json,
                 {"principal_id": None, "tenant_id": None, "type": "UserAssigned"},
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -348,7 +391,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.listeners.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -356,7 +400,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.load_distribution_policies.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -364,7 +409,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.location.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -372,7 +418,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.name.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -380,7 +427,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.operational_state.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -388,7 +436,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.private_endpoint_connections.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -396,7 +445,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.private_link_configurations.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -404,7 +454,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.probes.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -412,7 +463,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.provisioning_state.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -434,7 +486,8 @@ class TestSREApplicationGatewayComponent:
                         "target_listener": {"id": None},
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -467,7 +520,8 @@ class TestSREApplicationGatewayComponent:
                         "rule_type": "Basic",
                     },
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -475,7 +529,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.resource_guid.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -483,7 +538,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.rewrite_rule_sets.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -491,14 +547,15 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.routing_rules.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
     def test_application_gateway_sku(
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
-        assert application_gateway_component.application_gateway.sku.apply(
+        application_gateway_component.application_gateway.sku.apply(
             partial(
                 assert_equal,
                 network.outputs.ApplicationGatewaySkuResponse(
@@ -506,7 +563,8 @@ class TestSREApplicationGatewayComponent:
                     name="Standard_v2",
                     tier="Standard_v2",
                 ),
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -526,7 +584,8 @@ class TestSREApplicationGatewayComponent:
                         "name": "letsencryptcertificate",
                     }
                 ],
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -546,7 +605,8 @@ class TestSREApplicationGatewayComponent:
                     "min_protocol_version": "TLSv1_2",
                     "policy_type": "CustomV2",
                 },
-            )
+            ),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -554,7 +614,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.ssl_profiles.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -562,7 +623,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.tags.apply(
-            partial(assert_equal, {"key": "value"})
+            partial(assert_equal, {"key": "value"}),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -570,7 +632,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.trusted_client_certificates.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -578,7 +641,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.type.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -586,7 +650,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.url_path_maps.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -594,7 +659,8 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.web_application_firewall_configuration.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )
 
     @pulumi.runtime.test
@@ -602,5 +668,6 @@ class TestSREApplicationGatewayComponent:
         self, application_gateway_component: SREApplicationGatewayComponent
     ):
         application_gateway_component.application_gateway.zones.apply(
-            partial(assert_equal, None)
+            partial(assert_equal, None),
+            run_with_unknowns=True,
         )

--- a/tests/infrastructure/programs/sre/test_application_gateway.py
+++ b/tests/infrastructure/programs/sre/test_application_gateway.py
@@ -1,0 +1,560 @@
+from functools import partial
+
+import pulumi
+import pytest
+from pulumi_azure_native import network
+
+from data_safe_haven.infrastructure.programs.sre.application_gateway import (
+    SREApplicationGatewayComponent,
+    SREApplicationGatewayProps,
+)
+
+from ..resource_assertions import assert_equal, assert_equal_json
+
+
+@pytest.fixture
+def application_gateway_props(
+    identity_key_vault_reader,
+    resource_group,
+    sre_fqdn,
+    subnet_application_gateway,
+    subnet_guacamole_containers,
+) -> SREApplicationGatewayProps:
+    return SREApplicationGatewayProps(
+        key_vault_certificate_id="key_vault_certificate_id",
+        key_vault_identity=identity_key_vault_reader,
+        resource_group=resource_group,
+        sre_fqdn=sre_fqdn,
+        subnet_application_gateway=subnet_application_gateway,
+        subnet_guacamole_containers=subnet_guacamole_containers,
+    )
+
+
+@pytest.fixture
+def application_gateway_component(
+    application_gateway_props,
+    stack_name,
+    tags,
+) -> SREApplicationGatewayComponent:
+    return SREApplicationGatewayComponent(
+        name="ag-name",
+        stack_name=stack_name,
+        props=application_gateway_props,
+        tags=tags,
+    )
+
+
+class TestSREApplicationGatewayComponent:
+    @pulumi.runtime.test
+    def test_application_gateway(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        assert isinstance(
+            application_gateway_component.application_gateway,
+            network.ApplicationGateway,
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_authentication_certificates(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.authentication_certificates.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_autoscale_configuration(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.autoscale_configuration.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_backend_address_pools(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.backend_address_pools.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "backend_ip_configurations": None,
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "backend_addresses": [
+                            {"ip_address": "10.1.1.28"},
+                            {"ip_address": "10.1.1.29"},
+                            {"ip_address": "10.1.1.30"},
+                        ],
+                        "name": "appGatewayBackendGuacamole",
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_backend_http_settings_collection(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.backend_http_settings_collection.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "cookie_based_affinity": "Enabled",
+                        "name": "appGatewayBackendHttpSettings",
+                        "port": 80,
+                        "protocol": "Http",
+                        "request_timeout": 30,
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_backend_settings_collection(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.backend_settings_collection.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_custom_error_configurations(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.custom_error_configurations.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_default_predefined_ssl_policy(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.default_predefined_ssl_policy.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_enable_fips(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.enable_fips.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_enable_http2(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.enable_http2.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_etag(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.etag.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_firewall_policy(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.firewall_policy.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_force_firewall_policy_association(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.force_firewall_policy_association.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_frontend_ip_configurations(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.frontend_ip_configurations.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "name": "appGatewayFrontendIP",
+                        "private_ip_allocation_method": "Dynamic",
+                        "public_ip_address": {"id": None},
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_frontend_ports(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.frontend_ports.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "name": "appGatewayFrontendHttp",
+                        "port": 80,
+                    },
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "name": "appGatewayFrontendHttps",
+                        "port": 443,
+                    },
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_gateway_ip_configurations(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.gateway_ip_configurations.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "name": "appGatewayIP",
+                        "subnet": {"id": "subnet_application_gateway_id"},
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_global_configuration(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.global_configuration.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_http_listeners(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.http_listeners.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "frontend_ip_configuration": {"id": None},
+                        "frontend_port": {"id": None},
+                        "host_name": "sre.example.com",
+                        "name": "GuacamoleHttpListener",
+                        "protocol": "Http",
+                    },
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "frontend_ip_configuration": {"id": None},
+                        "frontend_port": {"id": None},
+                        "host_name": "sre.example.com",
+                        "name": "GuacamoleHttpsListener",
+                        "protocol": "Https",
+                        "ssl_certificate": {"id": None},
+                    },
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_identity(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.identity.apply(
+            partial(
+                assert_equal_json,
+                {"principal_id": None, "tenant_id": None, "type": "UserAssigned"},
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_listeners(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.listeners.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_load_distribution_policies(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.load_distribution_policies.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_location(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.location.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_name(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.name.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_operational_state(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.operational_state.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_private_endpoint_connections(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.private_endpoint_connections.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_private_link_configurations(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.private_link_configurations.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_probes(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.probes.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_provisioning_state(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.provisioning_state.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_redirect_configurations(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.redirect_configurations.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "type": None,
+                        "include_path": True,
+                        "include_query_string": True,
+                        "name": "GuacamoleHttpToHttpsRedirection",
+                        "redirect_type": "Permanent",
+                        "request_routing_rules": [{"id": None}],
+                        "target_listener": {"id": None},
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_request_routing_rules(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.request_routing_rules.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "http_listener": {"id": None},
+                        "name": "GuacamoleHttpRouting",
+                        "priority": 200,
+                        "redirect_configuration": {"id": None},
+                        "rule_type": "Basic",
+                    },
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "type": None,
+                        "backend_address_pool": {"id": None},
+                        "backend_http_settings": {"id": None},
+                        "http_listener": {"id": None},
+                        "name": "GuacamoleHttpsRouting",
+                        "priority": 100,
+                        "rule_type": "Basic",
+                    },
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_resource_guid(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.resource_guid.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_rewrite_rule_sets(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.rewrite_rule_sets.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_routing_rules(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.routing_rules.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_sku(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        assert application_gateway_component.application_gateway.sku.apply(
+            partial(
+                assert_equal,
+                network.outputs.ApplicationGatewaySkuResponse(
+                    capacity=1,
+                    name="Standard_v2",
+                    tier="Standard_v2",
+                ),
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_ssl_certificates(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.ssl_certificates.apply(
+            partial(
+                assert_equal_json,
+                [
+                    {
+                        "etag": None,
+                        "provisioning_state": None,
+                        "public_cert_data": None,
+                        "type": None,
+                        "key_vault_secret_id": "key_vault_certificate_id",
+                        "name": "letsencryptcertificate",
+                    }
+                ],
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_ssl_policy(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.ssl_policy.apply(
+            partial(
+                assert_equal_json,
+                {
+                    "cipher_suites": [
+                        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    ],
+                    "min_protocol_version": "TLSv1_2",
+                    "policy_type": "CustomV2",
+                },
+            )
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_ssl_profiles(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.ssl_profiles.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_tags(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.tags.apply(
+            partial(assert_equal, {"key": "value"})
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_trusted_client_certificates(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.trusted_client_certificates.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_type(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.type.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_url_path_maps(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.url_path_maps.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_web_application_firewall_configuration(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.web_application_firewall_configuration.apply(
+            partial(assert_equal, None)
+        )
+
+    @pulumi.runtime.test
+    def test_application_gateway_zones(
+        self, application_gateway_component: SREApplicationGatewayComponent
+    ):
+        application_gateway_component.application_gateway.zones.apply(
+            partial(assert_equal, None)
+        )

--- a/typings/pulumi/__init__.pyi
+++ b/typings/pulumi/__init__.pyi
@@ -6,6 +6,7 @@ from pulumi.config import (
 from pulumi.output import (
     Input,
     Output,
+    UNKNOWN,
 )
 from pulumi.resource import (
     ComponentResource,
@@ -24,4 +25,5 @@ __all__ = [
     "Output",
     "Resource",
     "ResourceOptions",
+    "UNKNOWN",
 ]


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->
n/a

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
Adds some proof-of-concept Pulumi unit tests for the SRE ApplicationGateway component.

**Note that much of what is described in the Pulumi documentation about Mocking does not seem to work with inline programs.**

Important notes:

- Pulumi `Outputs` should be tested within an `apply` loop with `run_with_unknowns` enabled, otherwise they will silently succeed on encountering any unknown values
- Value-based assertions need to be defined separately (currently in `resource_assertions.py`) as raw `assert` cannot be used inside an `apply` loop
- All tests must be decorated with `pulumi.runtime.test` or they will silently succeed
- Any sub-resource that we want to test needs to be exposed as an attribute of the Component class (e.g. `SREApplicationGateway` now has `self.application_gateway = ...` in its constructor so that we can test the ApplicationGateway resource.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Closes #1835

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
