### PR TITLE
Add more informative error messages to context commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ environment_configs/package_lists/dependency-cache.json
 
 # Python build caches
 __pycache__/
+.venv/
 
 # Development tools
 .vscode

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -186,7 +186,7 @@ def remove(
 def create() -> None:
     """Create Data Safe Haven context infrastructure."""
     try:
-        settings = ContextSettings.from_file().assert_context()
+        context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         print("No context configuration file. Run `dsh context add` before creating infrastructure.")
         raise typer.Exit(code=1) from exc
@@ -198,6 +198,10 @@ def create() -> None:
 @context_command_group.command()
 def teardown() -> None:
     """Tear down Data Safe Haven context infrastructure."""
-    context = ContextSettings.from_file().assert_context()
+    try:
+        context = ContextSettings.from_file().assert_context()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file. A context must be found before it can be torn down infrastructure.")
+        raise typer.Exit(code=1) from exc
     context_infra = ContextInfrastructure(context)
     context_infra.teardown()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -198,7 +198,7 @@ def create() -> None:
             print(
                 "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
 
     context_infra = ContextInfrastructure(context)
     try:

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -11,7 +11,7 @@ from data_safe_haven.context import (
     ContextSettings,
 )
 from data_safe_haven.context_infrastructure import ContextInfrastructure
-from data_safe_haven.exceptions import DataSafeHavenConfigError
+from data_safe_haven.exceptions import DataSafeHavenAzureAPIAuthenticationError, DataSafeHavenConfigError
 
 context_command_group = typer.Typer()
 
@@ -197,7 +197,11 @@ def create() -> None:
         raise typer.Exit(code=1)
 
     context_infra = ContextInfrastructure(context)
-    context_infra.create()
+    try:
+        context_infra.create()
+    except DataSafeHavenAzureAPIAuthenticationError:
+        print("Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`.")
+        raise typer.Exit(1)
 
 
 @context_command_group.command()
@@ -214,4 +218,8 @@ def teardown() -> None:
             )
         raise typer.Exit(code=1)
     context_infra = ContextInfrastructure(context)
-    context_infra.teardown()
+    try:
+        context_infra.teardown()
+    except DataSafeHavenAzureAPIAuthenticationError:
+        print("Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`.")
+        raise typer.Exit(1)

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -204,7 +204,7 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         print(
-            "No context configuration file. A context must be found before it can be torn down infrastructure."
+            "No context configuration file. A context must be configured before it can be torn down."
         )
         raise typer.Exit(code=1) from exc
     context_infra = ContextInfrastructure(context)

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -228,8 +228,8 @@ def teardown() -> None:
 
     try:
         context_infra.teardown()
-    except DataSafeHavenAzureAPIAuthenticationError:
+    except DataSafeHavenAzureAPIAuthenticationError as exc:
         print(
             "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(1) from exc

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -179,7 +179,7 @@ def remove(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
-        print("No context configuration file, so no contexts to remove.")
+        print("No context configuration file.")
         raise typer.Exit(code=1) from None
     settings.remove(key)
     settings.write()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -22,7 +22,7 @@ def show() -> None:
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file.")
+        print("No context configuration file. Run `dsh context add` to create one.")
         raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
@@ -39,7 +39,11 @@ def show() -> None:
 @context_command_group.command()
 def available() -> None:
     """Show the available contexts."""
-    settings = ContextSettings.from_file()
+    try:
+        settings = ContextSettings.from_file()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file. Run `dsh context add` to create one.")
+        raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
     available = settings.available
@@ -56,7 +60,11 @@ def switch(
     key: Annotated[str, typer.Argument(help="Key of the context to switch to.")]
 ) -> None:
     """Switch the selected context."""
-    settings = ContextSettings.from_file()
+    try:
+        settings = ContextSettings.from_file()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file. Run `dsh context add` to create one.")
+        raise typer.Exit(code=1) from exc
     settings.selected = key
     settings.write()
 
@@ -145,7 +153,12 @@ def update(
     ] = None,
 ) -> None:
     """Update the selected context settings."""
-    settings = ContextSettings.from_file()
+    try:
+        settings = ContextSettings.from_file()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file. Run `dsh context add` to create one.")
+        raise typer.Exit(code=1) from exc
+
     settings.update(
         admin_group_id=admin_group,
         location=location,
@@ -160,7 +173,11 @@ def remove(
     key: Annotated[str, typer.Argument(help="Name of the context to remove.")],
 ) -> None:
     """Removes a context."""
-    settings = ContextSettings.from_file()
+    try:
+        settings = ContextSettings.from_file()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file, so no contexts to remove.")
+        raise typer.Exit(code=1) from exc
     settings.remove(key)
     settings.write()
 
@@ -168,7 +185,12 @@ def remove(
 @context_command_group.command()
 def create() -> None:
     """Create Data Safe Haven context infrastructure."""
-    context = ContextSettings.from_file().assert_context()
+    try:
+        settings = ContextSettings.from_file().assert_context()
+    except DataSafeHavenConfigError as exc:
+        print("No context configuration file. Run `dsh context add` before creating infrastructure.")
+        raise typer.Exit(code=1) from exc
+
     context_infra = ContextInfrastructure(context)
     context_infra.create()
 

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -25,7 +25,7 @@ def show() -> None:
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
-        print("No context configuration file. Run `dsh context add` to create one.")
+        print("No context configuration file. Use `dsh context add` to create one.")
         raise typer.Exit(code=1) from None
 
     current_context_key = settings.selected
@@ -45,7 +45,7 @@ def available() -> None:
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
-        print("No context configuration file. Run `dsh context add` to create one.")
+        print("No context configuration file. Use `dsh context add` to create one.")
         raise typer.Exit(code=1) from None
 
     current_context_key = settings.selected
@@ -66,7 +66,7 @@ def switch(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
-        print("No context configuration file. Run `dsh context add` to create one.")
+        print("No context configuration file. Use `dsh context add` to create one.")
         raise typer.Exit(code=1) from None
     settings.selected = key
     settings.write()
@@ -160,7 +160,7 @@ def update(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
-        print("No context configuration file. Run `dsh context add` to create one.")
+        print("No context configuration file. Use `dsh context add` to create one.")
         raise typer.Exit(code=1) from None
 
     settings.update(
@@ -193,10 +193,10 @@ def create() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Run `dsh context switch` to select one.")
+            print("No context selected. Use `dsh context switch` to select one.")
         else:
             print(
-                "No context configuration file. Run `dsh context add` before creating infrastructure."
+                "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
         raise typer.Exit(code=1) from None
 
@@ -217,10 +217,10 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Run `dsh context switch` to select one.")
+            print("No context selected. Use `dsh context switch` to select one.")
         else:
             print(
-                "No context configuration file. Run `dsh context add` before creating infrastructure."
+                "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
         raise typer.Exit(code=1) from None
 

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -222,7 +222,9 @@ def teardown() -> None:
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
             )
         raise typer.Exit(code=1) from None
+
     context_infra = ContextInfrastructure(context)
+
     try:
         context_infra.teardown()
     except DataSafeHavenAzureAPIAuthenticationError:

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -189,7 +189,7 @@ def create() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Use `dsh context switch KEY` to select one.")
+            print("No context selected. Run `dsh context switch` to select one.")
         else:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
@@ -207,7 +207,7 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Use `dsh context switch KEY` to select one.")
+            print("No context selected. Run `dsh context switch` to select one.")
         else:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -179,9 +179,9 @@ def remove(
     """Removes a context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError:
+    except DataSafeHavenConfigError as exc:
         print("No context configuration file.")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
     settings.remove(key)
     settings.write()
 

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -159,9 +159,9 @@ def update(
     """Update the selected context settings."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError:
+    except DataSafeHavenConfigError as exc:
         print("No context configuration file. Use `dsh context add` to create one.")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
 
     settings.update(
         admin_group_id=admin_group,

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -188,7 +188,9 @@ def create() -> None:
     try:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. Run `dsh context add` before creating infrastructure.")
+        print(
+            "No context configuration file. Run `dsh context add` before creating infrastructure."
+        )
         raise typer.Exit(code=1) from exc
 
     context_infra = ContextInfrastructure(context)
@@ -201,7 +203,9 @@ def teardown() -> None:
     try:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. A context must be found before it can be torn down infrastructure.")
+        print(
+            "No context configuration file. A context must be found before it can be torn down infrastructure."
+        )
         raise typer.Exit(code=1) from exc
     context_infra = ContextInfrastructure(context)
     context_infra.teardown()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -3,7 +3,6 @@
 from typing import Annotated, Optional
 
 import typer
-from rich import print
 
 from data_safe_haven import validators
 from data_safe_haven.context import (
@@ -15,8 +14,10 @@ from data_safe_haven.exceptions import (
     DataSafeHavenAzureAPIAuthenticationError,
     DataSafeHavenConfigError,
 )
+from data_safe_haven.utility import LoggingSingleton
 
 context_command_group = typer.Typer()
+logger = LoggingSingleton()
 
 
 @context_command_group.command()
@@ -25,18 +26,20 @@ def show() -> None:
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. Use `dsh context add` to create one.")
+        logger.critical(
+            "No context configuration file. Use `dsh context add` to create one."
+        )
         raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
     current_context = settings.context
 
-    print(f"Current context: [green]{current_context_key}")
+    logger.info(f"Current context: [green]{current_context_key}")
     if current_context is not None:
-        print(f"\tName: {current_context.name}")
-        print(f"\tAdmin Group ID: {current_context.admin_group_id}")
-        print(f"\tSubscription name: {current_context.subscription_name}")
-        print(f"\tLocation: {current_context.location}")
+        logger.info(f"\tName: {current_context.name}")
+        logger.info(f"\tAdmin Group ID: {current_context.admin_group_id}")
+        logger.info(f"\tSubscription name: {current_context.subscription_name}")
+        logger.info(f"\tLocation: {current_context.location}")
 
 
 @context_command_group.command()
@@ -45,7 +48,9 @@ def available() -> None:
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. Use `dsh context add` to create one.")
+        logger.critical(
+            "No context configuration file. Use `dsh context add` to create one."
+        )
         raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
@@ -55,7 +60,7 @@ def available() -> None:
         available.remove(current_context_key)
         available = [f"[green]{current_context_key}*[/]", *available]
 
-    print("\n".join(available))
+    logger.info("\n".join(available))
 
 
 @context_command_group.command()
@@ -66,7 +71,9 @@ def switch(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. Use `dsh context add` to create one.")
+        logger.critical(
+            "No context configuration file. Use `dsh context add` to create one."
+        )
         raise typer.Exit(code=1) from exc
     settings.selected = key
     settings.write()
@@ -160,7 +167,9 @@ def update(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file. Use `dsh context add` to create one.")
+        logger.critical(
+            "No context configuration file. Use `dsh context add` to create one."
+        )
         raise typer.Exit(code=1) from exc
 
     settings.update(
@@ -180,7 +189,7 @@ def remove(
     try:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError as exc:
-        print("No context configuration file.")
+        logger.critical("No context configuration file.")
         raise typer.Exit(code=1) from exc
     settings.remove(key)
     settings.write()
@@ -193,9 +202,11 @@ def create() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Use `dsh context switch` to select one.")
+            logger.critical(
+                "No context selected. Use `dsh context switch` to select one."
+            )
         else:
-            print(
+            logger.critical(
                 "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
         raise typer.Exit(code=1) from exc
@@ -204,7 +215,7 @@ def create() -> None:
     try:
         context_infra.create()
     except DataSafeHavenAzureAPIAuthenticationError as exc:
-        print(
+        logger.critical(
             "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
         )
         raise typer.Exit(1) from exc
@@ -217,9 +228,11 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print("No context selected. Use `dsh context switch` to select one.")
+            logger.critical(
+                "No context selected. Use `dsh context switch` to select one."
+            )
         else:
-            print(
+            logger.critical(
                 "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
         raise typer.Exit(code=1) from exc
@@ -229,7 +242,7 @@ def teardown() -> None:
     try:
         context_infra.teardown()
     except DataSafeHavenAzureAPIAuthenticationError as exc:
-        print(
+        logger.critical(
             "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
         )
         raise typer.Exit(1) from exc

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -222,7 +222,7 @@ def teardown() -> None:
             print(
                 "No context configuration file. Use `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
 
     context_infra = ContextInfrastructure(context)
 

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -44,9 +44,9 @@ def available() -> None:
     """Show the available contexts."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError:
+    except DataSafeHavenConfigError as exc:
         print("No context configuration file. Use `dsh context add` to create one.")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
     available = settings.available

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -11,7 +11,10 @@ from data_safe_haven.context import (
     ContextSettings,
 )
 from data_safe_haven.context_infrastructure import ContextInfrastructure
-from data_safe_haven.exceptions import DataSafeHavenAzureAPIAuthenticationError, DataSafeHavenConfigError
+from data_safe_haven.exceptions import (
+    DataSafeHavenAzureAPIAuthenticationError,
+    DataSafeHavenConfigError,
+)
 
 context_command_group = typer.Typer()
 
@@ -23,7 +26,7 @@ def show() -> None:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
     current_context_key = settings.selected
     current_context = settings.context
@@ -43,7 +46,7 @@ def available() -> None:
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
     current_context_key = settings.selected
     available = settings.available
@@ -64,7 +67,7 @@ def switch(
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
     settings.selected = key
     settings.write()
 
@@ -157,7 +160,7 @@ def update(
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
     settings.update(
         admin_group_id=admin_group,
@@ -177,7 +180,7 @@ def remove(
         settings = ContextSettings.from_file()
     except DataSafeHavenConfigError:
         print("No context configuration file, so no contexts to remove.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
     settings.remove(key)
     settings.write()
 
@@ -194,14 +197,16 @@ def create() -> None:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
     context_infra = ContextInfrastructure(context)
     try:
         context_infra.create()
     except DataSafeHavenAzureAPIAuthenticationError:
-        print("Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`.")
-        raise typer.Exit(1)
+        print(
+            "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
+        )
+        raise typer.Exit(1) from None
 
 
 @context_command_group.command()
@@ -216,10 +221,12 @@ def teardown() -> None:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
     context_infra = ContextInfrastructure(context)
     try:
         context_infra.teardown()
     except DataSafeHavenAzureAPIAuthenticationError:
-        print("Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`.")
-        raise typer.Exit(1)
+        print(
+            "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
+        )
+        raise typer.Exit(1) from None

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -65,9 +65,9 @@ def switch(
     """Switch the selected context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError:
+    except DataSafeHavenConfigError as exc:
         print("No context configuration file. Use `dsh context add` to create one.")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
     settings.selected = key
     settings.write()
 

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -189,9 +189,7 @@ def create() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print(
-                "No context selected. Use `dsh context switch KEY` to select one."
-            )
+            print("No context selected. Use `dsh context switch KEY` to select one.")
         else:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
@@ -209,9 +207,7 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         if exc.args[0] == "No context selected":
-            print(
-                "No context selected. Use `dsh context switch KEY` to select one."
-            )
+            print("No context selected. Use `dsh context switch KEY` to select one.")
         else:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -24,9 +24,9 @@ def show() -> None:
     """Show information about the selected context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError:
+    except DataSafeHavenConfigError as exc:
         print("No context configuration file. Use `dsh context add` to create one.")
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=1) from exc
 
     current_context_key = settings.selected
     current_context = settings.context

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -21,9 +21,9 @@ def show() -> None:
     """Show information about the selected context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError as exc:
+    except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
 
     current_context_key = settings.selected
     current_context = settings.context
@@ -41,9 +41,9 @@ def available() -> None:
     """Show the available contexts."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError as exc:
+    except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
 
     current_context_key = settings.selected
     available = settings.available
@@ -62,9 +62,9 @@ def switch(
     """Switch the selected context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError as exc:
+    except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
     settings.selected = key
     settings.write()
 
@@ -155,9 +155,9 @@ def update(
     """Update the selected context settings."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError as exc:
+    except DataSafeHavenConfigError:
         print("No context configuration file. Run `dsh context add` to create one.")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
 
     settings.update(
         admin_group_id=admin_group,
@@ -175,9 +175,9 @@ def remove(
     """Removes a context."""
     try:
         settings = ContextSettings.from_file()
-    except DataSafeHavenConfigError as exc:
+    except DataSafeHavenConfigError:
         print("No context configuration file, so no contexts to remove.")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
     settings.remove(key)
     settings.write()
 
@@ -194,7 +194,7 @@ def create() -> None:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
 
     context_infra = ContextInfrastructure(context)
     context_infra.create()
@@ -212,6 +212,6 @@ def teardown() -> None:
             print(
                 "No context configuration file. Run `dsh context add` before creating infrastructure."
             )
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1)
     context_infra = ContextInfrastructure(context)
     context_infra.teardown()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -203,11 +203,11 @@ def create() -> None:
     context_infra = ContextInfrastructure(context)
     try:
         context_infra.create()
-    except DataSafeHavenAzureAPIAuthenticationError:
+    except DataSafeHavenAzureAPIAuthenticationError as exc:
         print(
             "Failed to authenticate with the Azure API. You may not be logged into the Azure CLI, or your login may have expired. Try running `az login`."
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(1) from exc
 
 
 @context_command_group.command()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -188,9 +188,14 @@ def create() -> None:
     try:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
-        print(
-            "No context configuration file. Run `dsh context add` before creating infrastructure."
-        )
+        if exc.args[0] == "No context selected":
+            print(
+                "No context selected. Use `dsh context switch KEY` to select one."
+            )
+        else:
+            print(
+                "No context configuration file. Run `dsh context add` before creating infrastructure."
+            )
         raise typer.Exit(code=1) from exc
 
     context_infra = ContextInfrastructure(context)
@@ -203,9 +208,14 @@ def teardown() -> None:
     try:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
-        print(
-            "No context configuration file. A context configuration must exist before the context can be torn down."
-        )
+        if exc.args[0] == "No context selected":
+            print(
+                "No context selected. Use `dsh context switch KEY` to select one."
+            )
+        else:
+            print(
+                "No context configuration file. Run `dsh context add` before creating infrastructure."
+            )
         raise typer.Exit(code=1) from exc
     context_infra = ContextInfrastructure(context)
     context_infra.teardown()

--- a/data_safe_haven/commands/context.py
+++ b/data_safe_haven/commands/context.py
@@ -204,7 +204,7 @@ def teardown() -> None:
         context = ContextSettings.from_file().assert_context()
     except DataSafeHavenConfigError as exc:
         print(
-            "No context configuration file. A context must be configured before it can be torn down."
+            "No context configuration file. A context configuration must exist before the context can be torn down."
         )
         raise typer.Exit(code=1) from exc
     context_infra = ContextInfrastructure(context)

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -11,12 +11,6 @@ class ContextInfrastructure:
         self.azure_api_: AzureApi | None = None
         self.context = context
         self.tags = {"component": "context"} | context.tags
-        try:
-            if self.azure_api.subscription_id:
-                pass
-        except Exception as exc:
-            msg = "Not logged in or login has expired. \nAuthenticate using az login before creating or tearing down context infrastructure."
-            raise DataSafeHavenAzureError(msg) from exc
 
     @property
     def azure_api(self) -> AzureApi:

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -10,6 +10,12 @@ class ContextInfrastructure:
         self.azure_api_: AzureApi | None = None
         self.context = context
         self.tags = {"component": "context"} | context.tags
+        try:
+            if self.azure_api.subscription_id:
+                pass
+        except Exception as exc:
+            msg = "Not logged in. \n Authenticate using az login before creating or tearing down context infrastructure."
+            raise DataSafeHavenAzureError(msg) from exc
 
     @property
     def azure_api(self) -> AzureApi:

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -1,6 +1,7 @@
 from data_safe_haven.context import Context
 from data_safe_haven.exceptions import DataSafeHavenAzureError
 from data_safe_haven.external import AzureApi
+from data_safe_haven.utility import LoggingSingleton
 
 
 class ContextInfrastructure:
@@ -94,7 +95,11 @@ class ContextInfrastructure:
         Raises:
             DataSafeHavenAzureError if any resources cannot be destroyed
         """
+        logger = LoggingSingleton
         try:
+            logger.info(
+                f"Removing context {self.context.name} resource group {self.context.resource_group_name}"
+            )
             self.azure_api.remove_resource_group(self.context.resource_group_name)
         except Exception as exc:
             msg = f"Failed to destroy context resources.\n{exc}"

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -79,7 +79,7 @@ class ContextInfrastructure:
                 key_name=self.context.pulumi_encryption_key_name,
                 key_vault_name=keyvault.name,
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create context resources.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -95,6 +95,6 @@ class ContextInfrastructure:
                 f"Removing context {self.context.name} resource group {self.context.resource_group_name}"
             )
             self.azure_api.remove_resource_group(self.context.resource_group_name)
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to destroy context resources.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -89,7 +89,7 @@ class ContextInfrastructure:
         Raises:
             DataSafeHavenAzureError if any resources cannot be destroyed
         """
-        logger = LoggingSingleton
+        logger = LoggingSingleton()
         try:
             logger.info(
                 f"Removing context {self.context.name} resource group {self.context.resource_group_name}"

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -14,7 +14,7 @@ class ContextInfrastructure:
             if self.azure_api.subscription_id:
                 pass
         except Exception as exc:
-            msg = "Not logged in. \nAuthenticate using az login before creating or tearing down context infrastructure."
+            msg = "Not logged in or login has expired. \nAuthenticate using az login before creating or tearing down context infrastructure."
             raise DataSafeHavenAzureError(msg) from exc
 
     @property

--- a/data_safe_haven/context_infrastructure/infrastructure.py
+++ b/data_safe_haven/context_infrastructure/infrastructure.py
@@ -14,7 +14,7 @@ class ContextInfrastructure:
             if self.azure_api.subscription_id:
                 pass
         except Exception as exc:
-            msg = "Not logged in. \n Authenticate using az login before creating or tearing down context infrastructure."
+            msg = "Not logged in. \nAuthenticate using az login before creating or tearing down context infrastructure."
             raise DataSafeHavenAzureError(msg) from exc
 
     @property

--- a/data_safe_haven/exceptions/__init__.py
+++ b/data_safe_haven/exceptions/__init__.py
@@ -42,7 +42,7 @@ class DataSafeHavenAzureError(DataSafeHavenCloudError):
     pass
 
 
-class DataSafeHavenAzureAPIError(DataSafeHavenAzureError):
+class DataSafeHavenAzureAPIError(DataSafeHavenError):
     pass
 
 

--- a/data_safe_haven/exceptions/__init__.py
+++ b/data_safe_haven/exceptions/__init__.py
@@ -42,6 +42,14 @@ class DataSafeHavenAzureError(DataSafeHavenCloudError):
     pass
 
 
+class DataSafeHavenAzureAPIError(DataSafeHavenAzureError):
+    pass
+
+
+class DataSafeHavenAzureAPIAuthenticationError(DataSafeHavenAzureAPIError):
+    pass
+
+
 class DataSafeHavenUserHandlingError(DataSafeHavenInternalError):
     pass
 

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -139,7 +139,7 @@ class AzureApi(AzureAuthenticator):
             )
             # Download the requested file
             return str(blob_client.download_blob(encoding="utf-8").readall())
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Blob file '{blob_name}' could not be downloaded from '{storage_account_name}'\n{exc}."
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -179,7 +179,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that DNS record {record_name} exists in zone {zone_name}.",
             )
             return record_set
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = (
                 f"Failed to create DNS record {record_name} in zone {zone_name}.\n{exc}"
             )
@@ -258,7 +258,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that key vault [green]{key_vaults[0].name}[/] exists.",
             )
             return key_vaults[0]
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create key vault {key_vault_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -295,7 +295,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that key [green]{key_name}[/] exists.",
             )
             return key
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create key {key_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -329,7 +329,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that managed identity [green]{identity_name}[/] exists.",
             )
             return managed_identity
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create managed identity {identity_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -371,7 +371,7 @@ class AzureApi(AzureAuthenticator):
                 f" in [green]{resource_groups[0].location}[/].",
             )
             return resource_groups[0]
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create resource group {resource_group_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -413,7 +413,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that storage account [green]{storage_account.name}[/] exists.",
             )
             return storage_account
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to create storage account {storage_account_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -471,7 +471,7 @@ class AzureApi(AzureAuthenticator):
         # Ensure that certificate exists
         try:
             return certificate_client.get_certificate(certificate_name)
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to retrieve certificate {certificate_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -492,7 +492,7 @@ class AzureApi(AzureAuthenticator):
         # Ensure that certificate exists
         try:
             return key_client.get_key(key_name)
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to retrieve key {key_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -516,7 +516,7 @@ class AzureApi(AzureAuthenticator):
                 return str(secret.value)
             msg = f"Secret {secret_name} has no value."
             raise DataSafeHavenAzureError(msg)
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to retrieve secret {secret_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -537,7 +537,7 @@ class AzureApi(AzureAuthenticator):
                     ),
                 )
             ]
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Azure locations could not be loaded.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -577,7 +577,7 @@ class AzureApi(AzureAuthenticator):
                 msg = f"No keys were retrieved for {msg_sa} in {msg_rg}."
                 raise DataSafeHavenAzureError(msg)
             return keys
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Keys could not be loaded for {msg_sa} in {msg_rg}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -621,7 +621,7 @@ class AzureApi(AzureAuthenticator):
                 f"Imported certificate [green]{certificate_name}[/].",
             )
             return certificate
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to import certificate '{certificate_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -649,7 +649,7 @@ class AzureApi(AzureAuthenticator):
                         ):
                             skus[resource_sku.name][capability.name] = capability.value
             return skus
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to load available VM sizes for Azure location {location}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -686,7 +686,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Purged certificate [green]{certificate_name}[/] from Key Vault [green]{key_vault_name}[/].",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to remove certificate '{certificate_name}' from Key Vault '{key_vault_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -724,7 +724,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Removed file [green]{blob_name}[/] from blob storage.",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Blob file [green]'{blob_name}'[/] could not be removed from [green]'{storage_account_name}'[/].\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -768,7 +768,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Ensured that DNS record [green]{record_name}[/] is removed from zone [green]{zone_name}[/].",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to remove DNS record [green]{record_name}[/] from zone [green]{zone_name}[/].\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -825,7 +825,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Removed certificate [green]{certificate_name}[/] from Key Vault [green]{key_vault_name}[/].",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to remove certificate '{certificate_name}' from Key Vault '{key_vault_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -869,7 +869,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Ensured that resource group [green]{resource_group_name}[/] does not exist.",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to remove resource group {resource_group_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -921,7 +921,7 @@ class AzureApi(AzureAuthenticator):
             result = cast(RunCommandResult, poller.result())
             # Return any stdout/stderr from the command
             return str(result.value[0].message) if result.value else ""
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to run command on '{vm_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -1002,7 +1002,7 @@ class AzureApi(AzureAuthenticator):
             directory_client = file_system_client._get_root_directory_client()
             # Set the desired ACL
             directory_client.set_access_control_recursive(acl=desired_acl)
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Failed to set ACL '{desired_acl}' on container '{container_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -1034,6 +1034,6 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Uploaded file [green]{blob_name}[/] to blob storage.",
             )
-        except Exception as exc:
+        except DataSafeHavenAzureError as exc:
             msg = f"Blob file '{blob_name}' could not be uploaded to '{storage_account_name}'\n{exc}."
             raise DataSafeHavenAzureError(msg) from exc

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -841,15 +841,15 @@ class AzureApi(AzureAuthenticator):
                 self.credential, self.subscription_id
             )
 
-            # Ensure that resource group exists
-            self.logger.debug(
-                f"Removing resource group [green]{resource_group_name}[/] if it exists...",
-            )
             if not resource_client.resource_groups.check_existence(resource_group_name):
-                self.logger.error(
-                    f"Resource group [green]{resource_group_name}[/] does not exist. There is no context infrastructure to teardown.",
+                self.logger.warning(
+                    f"Resource group [green]{resource_group_name}[/] does not exist.",
                 )
                 return
+            # Ensure that resource group exists
+            self.logger.debug(
+                f"Attempting to remove resource group [green]{resource_group_name}[/]",
+            )
             poller = resource_client.resource_groups.begin_delete(
                 resource_group_name,
             )

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 from typing import Any, cast
 
 from azure.core.exceptions import (
+    AzureError,
     HttpResponseError,
     ResourceExistsError,
     ResourceNotFoundError,
@@ -139,7 +140,7 @@ class AzureApi(AzureAuthenticator):
             )
             # Download the requested file
             return str(blob_client.download_blob(encoding="utf-8").readall())
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Blob file '{blob_name}' could not be downloaded from '{storage_account_name}'\n{exc}."
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -179,7 +180,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that DNS record {record_name} exists in zone {zone_name}.",
             )
             return record_set
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = (
                 f"Failed to create DNS record {record_name} in zone {zone_name}.\n{exc}"
             )
@@ -258,7 +259,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that key vault [green]{key_vaults[0].name}[/] exists.",
             )
             return key_vaults[0]
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to create key vault {key_vault_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -295,7 +296,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that key [green]{key_name}[/] exists.",
             )
             return key
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to create key {key_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -329,7 +330,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that managed identity [green]{identity_name}[/] exists.",
             )
             return managed_identity
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to create managed identity {identity_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -371,7 +372,7 @@ class AzureApi(AzureAuthenticator):
                 f" in [green]{resource_groups[0].location}[/].",
             )
             return resource_groups[0]
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to create resource group {resource_group_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -413,7 +414,7 @@ class AzureApi(AzureAuthenticator):
                 f"Ensured that storage account [green]{storage_account.name}[/] exists.",
             )
             return storage_account
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to create storage account {storage_account_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -471,7 +472,7 @@ class AzureApi(AzureAuthenticator):
         # Ensure that certificate exists
         try:
             return certificate_client.get_certificate(certificate_name)
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to retrieve certificate {certificate_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -516,7 +517,7 @@ class AzureApi(AzureAuthenticator):
                 return str(secret.value)
             msg = f"Secret {secret_name} has no value."
             raise DataSafeHavenAzureError(msg)
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to retrieve secret {secret_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -537,7 +538,7 @@ class AzureApi(AzureAuthenticator):
                     ),
                 )
             ]
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Azure locations could not be loaded.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -577,7 +578,7 @@ class AzureApi(AzureAuthenticator):
                 msg = f"No keys were retrieved for {msg_sa} in {msg_rg}."
                 raise DataSafeHavenAzureError(msg)
             return keys
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Keys could not be loaded for {msg_sa} in {msg_rg}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -621,7 +622,7 @@ class AzureApi(AzureAuthenticator):
                 f"Imported certificate [green]{certificate_name}[/].",
             )
             return certificate
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to import certificate '{certificate_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -649,7 +650,7 @@ class AzureApi(AzureAuthenticator):
                         ):
                             skus[resource_sku.name][capability.name] = capability.value
             return skus
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to load available VM sizes for Azure location {location}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -686,7 +687,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Purged certificate [green]{certificate_name}[/] from Key Vault [green]{key_vault_name}[/].",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to remove certificate '{certificate_name}' from Key Vault '{key_vault_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -724,7 +725,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Removed file [green]{blob_name}[/] from blob storage.",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Blob file [green]'{blob_name}'[/] could not be removed from [green]'{storage_account_name}'[/].\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -768,7 +769,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Ensured that DNS record [green]{record_name}[/] is removed from zone [green]{zone_name}[/].",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to remove DNS record [green]{record_name}[/] from zone [green]{zone_name}[/].\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -825,7 +826,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Removed certificate [green]{certificate_name}[/] from Key Vault [green]{key_vault_name}[/].",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to remove certificate '{certificate_name}' from Key Vault '{key_vault_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -869,7 +870,7 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Ensured that resource group [green]{resource_group_name}[/] does not exist.",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to remove resource group {resource_group_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -921,7 +922,7 @@ class AzureApi(AzureAuthenticator):
             result = cast(RunCommandResult, poller.result())
             # Return any stdout/stderr from the command
             return str(result.value[0].message) if result.value else ""
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to run command on '{vm_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -949,7 +950,7 @@ class AzureApi(AzureAuthenticator):
                     vm_name=vm_name,
                 )
                 break
-            except DataSafeHavenAzureError as exc:
+            except AzureError as exc:
                 if all(
                     reason not in str(exc)
                     for reason in (
@@ -1002,7 +1003,7 @@ class AzureApi(AzureAuthenticator):
             directory_client = file_system_client._get_root_directory_client()
             # Set the desired ACL
             directory_client.set_access_control_recursive(acl=desired_acl)
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Failed to set ACL '{desired_acl}' on container '{container_name}'.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 
@@ -1034,6 +1035,6 @@ class AzureApi(AzureAuthenticator):
             self.logger.info(
                 f"Uploaded file [green]{blob_name}[/] to blob storage.",
             )
-        except DataSafeHavenAzureError as exc:
+        except AzureError as exc:
             msg = f"Blob file '{blob_name}' could not be uploaded to '{storage_account_name}'\n{exc}."
             raise DataSafeHavenAzureError(msg) from exc

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -845,6 +845,11 @@ class AzureApi(AzureAuthenticator):
             self.logger.debug(
                 f"Removing resource group [green]{resource_group_name}[/] if it exists...",
             )
+            if not resource_client.resource_groups.check_existence(resource_group_name):
+                self.logger.error(
+                    f"Resource group [green]{resource_group_name}[/] does not exist. There is no context infrastructure to teardown.",
+                )
+                return
             poller = resource_client.resource_groups.begin_delete(
                 resource_group_name,
             )

--- a/data_safe_haven/external/api/azure_api.py
+++ b/data_safe_haven/external/api/azure_api.py
@@ -492,7 +492,7 @@ class AzureApi(AzureAuthenticator):
         # Ensure that certificate exists
         try:
             return key_client.get_key(key_name)
-        except DataSafeHavenAzureError as exc:
+        except (ResourceNotFoundError, HttpResponseError) as exc:
             msg = f"Failed to retrieve key {key_name}.\n{exc}"
             raise DataSafeHavenAzureError(msg) from exc
 

--- a/data_safe_haven/external/interface/azure_authenticator.py
+++ b/data_safe_haven/external/interface/azure_authenticator.py
@@ -9,6 +9,7 @@ from azure.mgmt.resource.subscriptions.models import Subscription
 
 from data_safe_haven.exceptions import (
     DataSafeHavenAzureError,
+    DataSafeHavenAzureAPIAuthenticationError,
     DataSafeHavenInputError,
 )
 
@@ -63,8 +64,8 @@ class AzureAuthenticator:
                     self.tenant_id_ = subscription.tenant_id
                     break
         except ClientAuthenticationError as exc:
-            msg = f"Failed to authenticate with Azure.\n{exc}"
-            raise DataSafeHavenAzureError(msg) from exc
+            msg = f"Failed to authenticate with Azure API.\n{exc}"
+            raise DataSafeHavenAzureAPIAuthenticationError(msg) from exc
         if not (self.subscription_id and self.tenant_id):
             msg = f"Could not find subscription '{self.subscription_name}'"
             raise DataSafeHavenInputError(msg)

--- a/data_safe_haven/external/interface/azure_authenticator.py
+++ b/data_safe_haven/external/interface/azure_authenticator.py
@@ -8,8 +8,8 @@ from azure.mgmt.resource.subscriptions import SubscriptionClient
 from azure.mgmt.resource.subscriptions.models import Subscription
 
 from data_safe_haven.exceptions import (
-    DataSafeHavenAzureError,
     DataSafeHavenAzureAPIAuthenticationError,
+    DataSafeHavenAzureError,
     DataSafeHavenInputError,
 )
 

--- a/tests/commands/test_context.py
+++ b/tests/commands/test_context.py
@@ -1,5 +1,7 @@
 from data_safe_haven.commands.context import context_command_group
 from data_safe_haven.context_infrastructure import ContextInfrastructure
+from data_safe_haven.exceptions import DataSafeHavenAzureAPIAuthenticationError
+from data_safe_haven.external.interface.azure_authenticator import AzureAuthenticator
 
 
 class TestShow:
@@ -223,6 +225,16 @@ class TestCreate:
         assert result.exit_code == 1
         assert "No context selected." in result.stdout
 
+    def test_auth_failure(self, runner, mocker):
+        def mock_login(self):  # noqa: ARG001
+            raise DataSafeHavenAzureAPIAuthenticationError
+
+        mocker.patch.object(AzureAuthenticator, "login", mock_login)
+
+        result = runner.invoke(context_command_group, ["create"])
+        assert result.exit_code == 1
+        assert "Failed to authenticate with the Azure API." in result.stdout
+
 
 class TestTeardown:
     def test_teardown(self, runner, monkeypatch):
@@ -244,3 +256,13 @@ class TestTeardown:
         result = runner_none.invoke(context_command_group, ["teardown"])
         assert result.exit_code == 1
         assert "No context selected." in result.stdout
+
+    def test_auth_failure(self, runner, mocker):
+        def mock_login(self):  # noqa: ARG001
+            raise DataSafeHavenAzureAPIAuthenticationError
+
+        mocker.patch.object(AzureAuthenticator, "login", mock_login)
+
+        result = runner.invoke(context_command_group, ["teardown"])
+        assert result.exit_code == 1
+        assert "Failed to authenticate with the Azure API." in result.stdout

--- a/tests/commands/test_context.py
+++ b/tests/commands/test_context.py
@@ -33,6 +33,11 @@ class TestAvailable:
         assert "acme_deployment" in result.stdout
         assert "gems" in result.stdout
 
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["available"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
+
 
 class TestSwitch:
     def test_switch(self, runner):
@@ -48,6 +53,11 @@ class TestSwitch:
         assert result.exit_code == 1
         # Unable to check error as this is written outside of any Typer
         # assert "Context 'invalid' is not defined " in result.stdout
+
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["switch", "context"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
 
 
 class TestAdd:
@@ -160,6 +170,11 @@ class TestUpdate:
         assert result.exit_code == 0
         assert "Name: New Name" in result.stdout
 
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["update", "--name", "New Name"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
+
 
 class TestRemove:
     def test_remove(self, runner):
@@ -175,6 +190,11 @@ class TestRemove:
         # Unable to check error as this is written outside of any Typer
         # assert "No context with key 'invalid'." in result.stdout
 
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["remove", "gems"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
+
 
 class TestCreate:
     def test_create(self, runner, monkeypatch):
@@ -187,6 +207,16 @@ class TestCreate:
         assert "mock create" in result.stdout
         assert result.exit_code == 0
 
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["create"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
+
+    def test_show_none(self, runner_none):
+        result = runner_none.invoke(context_command_group, ["create"])
+        assert result.exit_code == 1
+        assert "No context selected." in result.stdout
+
 
 class TestTeardown:
     def test_teardown(self, runner, monkeypatch):
@@ -198,3 +228,13 @@ class TestTeardown:
         result = runner.invoke(context_command_group, ["teardown"])
         assert "mock teardown" in result.stdout
         assert result.exit_code == 0
+
+    def test_no_context_file(self, runner_no_context_file):
+        result = runner_no_context_file.invoke(context_command_group, ["teardown"])
+        assert result.exit_code == 1
+        assert "No context configuration file." in result.stdout
+
+    def test_show_none(self, runner_none):
+        result = runner_none.invoke(context_command_group, ["teardown"])
+        assert result.exit_code == 1
+        assert "No context selected." in result.stdout

--- a/tests/commands/test_context.py
+++ b/tests/commands/test_context.py
@@ -55,7 +55,9 @@ class TestSwitch:
         # assert "Context 'invalid' is not defined " in result.stdout
 
     def test_no_context_file(self, runner_no_context_file):
-        result = runner_no_context_file.invoke(context_command_group, ["switch", "context"])
+        result = runner_no_context_file.invoke(
+            context_command_group, ["switch", "context"]
+        )
         assert result.exit_code == 1
         assert "No context configuration file." in result.stdout
 
@@ -171,7 +173,9 @@ class TestUpdate:
         assert "Name: New Name" in result.stdout
 
     def test_no_context_file(self, runner_no_context_file):
-        result = runner_no_context_file.invoke(context_command_group, ["update", "--name", "New Name"])
+        result = runner_no_context_file.invoke(
+            context_command_group, ["update", "--name", "New Name"]
+        )
         assert result.exit_code == 1
         assert "No context configuration file." in result.stdout
 
@@ -191,7 +195,9 @@ class TestRemove:
         # assert "No context with key 'invalid'." in result.stdout
 
     def test_no_context_file(self, runner_no_context_file):
-        result = runner_no_context_file.invoke(context_command_group, ["remove", "gems"])
+        result = runner_no_context_file.invoke(
+            context_command_group, ["remove", "gems"]
+        )
         assert result.exit_code == 1
         assert "No context configuration file." in result.stdout
 

--- a/tests/external/api/test_azure_api.py
+++ b/tests/external/api/test_azure_api.py
@@ -1,4 +1,5 @@
 import pytest
+from azure.core.exceptions import ResourceNotFoundError
 from pytest import fixture
 
 import data_safe_haven.external.api.azure_api
@@ -17,7 +18,7 @@ def mock_key_client(monkeypatch):
             if key_name == "exists":
                 return f"key: {key_name}"
             else:
-                raise Exception
+                raise ResourceNotFoundError
 
     monkeypatch.setattr(
         data_safe_haven.external.api.azure_api, "KeyClient", MockKeyClient


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Adds more informative messages when users try to use context functions without first having created a context file.

Catches that user is not logged in when trying to create or teardown context infrastructure.

WIP: Catch that no context infrastructure is deployed

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1897
Closes #1899 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

tested locally
