### PR TITLE
Validate SHM/SRE for user commands

### DIFF
--- a/data_safe_haven/commands/users.py
+++ b/data_safe_haven/commands/users.py
@@ -32,6 +32,11 @@ def add(
 
     shm_name = context.shm_name
 
+    logger = LoggingSingleton()
+    if shm_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{shm_name}'.\nHave you deployed the SHM?")
+        raise typer.Exit(1)
+
     try:
         # Load GraphAPI
         graph_api = GraphApi(
@@ -59,6 +64,11 @@ def list_users() -> None:
     pulumi_config = DSHPulumiConfig.from_remote(context)
 
     shm_name = context.shm_name
+
+    logger = LoggingSingleton()
+    if shm_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{shm_name}'.\nHave you deployed the SHM?")
+        raise typer.Exit(1)
 
     try:
         # Load GraphAPI
@@ -101,12 +111,17 @@ def register(
     # Use a JSON-safe SRE name
     sre_name = sanitise_sre_name(sre)
 
+    logger = LoggingSingleton()
+    if shm_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{shm_name}'.\nHave you deployed the SHM?")
+        raise typer.Exit(1)
+
+    if sre_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{sre_name}'.\nHave you deployed the SRE?")
+        raise typer.Exit(1)
+
     try:
-        # Check that SRE option has been provided
-        if not sre_name:
-            msg = "SRE name must be specified."
-            raise DataSafeHavenError(msg)
-        LoggingSingleton().info(
+        logger.info(
             f"Preparing to register {len(usernames)} user(s) with SRE '{sre_name}'"
         )
 
@@ -124,7 +139,7 @@ def register(
             if username in available_usernames:
                 usernames_to_register.append(username)
             else:
-                LoggingSingleton().error(
+                logger.error(
                     f"Username '{username}' does not belong to this Data Safe Haven deployment."
                     " Please use 'dsh users add' to create it."
                 )
@@ -151,6 +166,11 @@ def remove(
     pulumi_config = DSHPulumiConfig.from_remote(context)
 
     shm_name = context.shm_name
+
+    logger = LoggingSingleton()
+    if shm_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{shm_name}'.\nHave you deployed the SHM?")
+        raise typer.Exit(1)
 
     try:
         # Load GraphAPI
@@ -193,12 +213,17 @@ def unregister(
     shm_name = context.shm_name
     sre_name = sanitise_sre_name(sre)
 
+    logger = LoggingSingleton()
+    if shm_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{shm_name}'.\nHave you deployed the SHM?")
+        raise typer.Exit(1)
+
+    if sre_name not in pulumi_config.project_names:
+        logger.fatal(f"No Pulumi project for '{sre_name}'.\nHave you deployed the SRE?")
+        raise typer.Exit(1)
+
     try:
-        # Check that SRE option has been provided
-        if not sre_name:
-            msg = "SRE name must be specified."
-            raise DataSafeHavenError(msg)
-        LoggingSingleton().info(
+        logger.info(
             f"Preparing to unregister {len(usernames)} users with SRE '{sre_name}'"
         )
 
@@ -216,7 +241,7 @@ def unregister(
             if username in available_usernames:
                 usernames_to_unregister.append(username)
             else:
-                LoggingSingleton().error(
+                logger.error(
                     f"Username '{username}' does not belong to this Data Safe Haven deployment."
                     " Please use 'dsh users add' to create it."
                 )

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -36,6 +36,17 @@ def tmp_contexts(tmp_path, context_settings):
 
 
 @fixture
+def tmp_contexts_gems(tmp_path, context_settings):
+    context_settings = context_settings.replace(
+        "selected: acme_deployment", "selected: gems"
+    )
+    config_file_path = tmp_path / "contexts.yaml"
+    with open(config_file_path, "w") as f:
+        f.write(context_settings)
+    return tmp_path
+
+
+@fixture
 def tmp_contexts_none(tmp_path, context_settings):
     context_settings = context_settings.replace(
         "selected: acme_deployment", "selected: null"

--- a/tests/commands/test_users.py
+++ b/tests/commands/test_users.py
@@ -13,3 +13,83 @@ class TestAdd:
 
         assert result.exit_code == 1
         assert "Have you deployed the SHM?" in result.stdout
+
+
+class TestListUsers:
+    def test_invalid_shm(
+        self,
+        runner,
+        tmp_contexts_gems,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["list"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SHM?" in result.stdout
+
+
+class TestRegister:
+    def test_invalid_shm(
+        self,
+        runner,
+        tmp_contexts_gems,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["register", "-u", "Harry Lime", "my_sre"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SHM?" in result.stdout
+
+    def test_invalid_sre(
+        self,
+        runner,
+        tmp_contexts,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["register", "-u", "Harry Lime", "my_sre"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SRE?" in result.stdout
+
+
+class TestRemove:
+    def test_invalid_shm(
+        self,
+        runner,
+        tmp_contexts_gems,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["remove", "-u", "Harry Lime"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SHM?" in result.stdout
+
+
+class TestUnregister:
+    def test_invalid_shm(
+        self,
+        runner,
+        tmp_contexts_gems,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SHM?" in result.stdout
+
+    def test_invalid_sre(
+        self,
+        runner,
+        tmp_contexts,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SRE?" in result.stdout

--- a/tests/commands/test_users.py
+++ b/tests/commands/test_users.py
@@ -4,7 +4,6 @@ from data_safe_haven.commands.users import users_command_group
 class TestAdd:
     def test_invalid_shm(
         self,
-        mocker,
         runner,
         tmp_contexts_gems,  # noqa: ARG002
         mock_config_from_remote,  # noqa: ARG002

--- a/tests/commands/test_users.py
+++ b/tests/commands/test_users.py
@@ -37,7 +37,9 @@ class TestRegister:
         mock_config_from_remote,  # noqa: ARG002
         mock_pulumi_config_from_remote,  # noqa: ARG002
     ):
-        result = runner.invoke(users_command_group, ["register", "-u", "Harry Lime", "my_sre"])
+        result = runner.invoke(
+            users_command_group, ["register", "-u", "Harry Lime", "my_sre"]
+        )
 
         assert result.exit_code == 1
         assert "Have you deployed the SHM?" in result.stdout
@@ -49,7 +51,9 @@ class TestRegister:
         mock_config_from_remote,  # noqa: ARG002
         mock_pulumi_config_from_remote,  # noqa: ARG002
     ):
-        result = runner.invoke(users_command_group, ["register", "-u", "Harry Lime", "my_sre"])
+        result = runner.invoke(
+            users_command_group, ["register", "-u", "Harry Lime", "my_sre"]
+        )
 
         assert result.exit_code == 1
         assert "Have you deployed the SRE?" in result.stdout
@@ -77,7 +81,9 @@ class TestUnregister:
         mock_config_from_remote,  # noqa: ARG002
         mock_pulumi_config_from_remote,  # noqa: ARG002
     ):
-        result = runner.invoke(users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"])
+        result = runner.invoke(
+            users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"]
+        )
 
         assert result.exit_code == 1
         assert "Have you deployed the SHM?" in result.stdout
@@ -89,7 +95,9 @@ class TestUnregister:
         mock_config_from_remote,  # noqa: ARG002
         mock_pulumi_config_from_remote,  # noqa: ARG002
     ):
-        result = runner.invoke(users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"])
+        result = runner.invoke(
+            users_command_group, ["unregister", "-u", "Harry Lime", "my_sre"]
+        )
 
         assert result.exit_code == 1
         assert "Have you deployed the SRE?" in result.stdout

--- a/tests/commands/test_users.py
+++ b/tests/commands/test_users.py
@@ -1,0 +1,16 @@
+from data_safe_haven.commands.users import users_command_group
+
+
+class TestAdd:
+    def test_invalid_shm(
+        self,
+        mocker,
+        runner,
+        tmp_contexts_gems,  # noqa: ARG002
+        mock_config_from_remote,  # noqa: ARG002
+        mock_pulumi_config_from_remote,  # noqa: ARG002
+    ):
+        result = runner.invoke(users_command_group, ["add", "users.csv"])
+
+        assert result.exit_code == 1
+        assert "Have you deployed the SHM?" in result.stdout


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Add checks that Pulumi configuration for SHM/SREs exists.
This is a proxy for ensuring the infrastructure exists.
It should be more reliable that just checking if the names are used in the DSH configuration, and much lighter weight than checking for particular pieces of infrastructure (either using Azure API or looking through the Pulumi stack).

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #1879 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
