### PR TITLE
Improve credential logging and choice

### DIFF
--- a/data_safe_haven/external/api/azure_sdk.py
+++ b/data_safe_haven/external/api/azure_sdk.py
@@ -168,7 +168,7 @@ class AzureSdk:
     ) -> AzureSdkCredential:
         if scope not in self._credentials:
             self._credentials[scope] = AzureSdkCredential(
-                scope, confirm_credentials=(not self.disable_logging)
+                scope, skip_confirmation=self.disable_logging
             )
         return self._credentials[scope]
 

--- a/data_safe_haven/external/api/azure_sdk.py
+++ b/data_safe_haven/external/api/azure_sdk.py
@@ -82,6 +82,7 @@ class AzureSdk:
         self, subscription_name: str, *, disable_logging: bool = False
     ) -> None:
         self._credentials: dict[AzureSdkCredentialScope, AzureSdkCredential] = {}
+        self.disable_logging = disable_logging
         self.logger = get_null_logger() if disable_logging else get_logger()
         self.subscription_name = subscription_name
         self.subscription_id_: str | None = None
@@ -166,7 +167,9 @@ class AzureSdk:
         self, scope: AzureSdkCredentialScope = AzureSdkCredentialScope.DEFAULT
     ) -> AzureSdkCredential:
         if scope not in self._credentials:
-            self._credentials[scope] = AzureSdkCredential(scope)
+            self._credentials[scope] = AzureSdkCredential(
+                scope, confirm_credentials=(not self.disable_logging)
+            )
         return self._credentials[scope]
 
     def download_blob(

--- a/data_safe_haven/external/api/credentials.py
+++ b/data_safe_haven/external/api/credentials.py
@@ -120,9 +120,9 @@ class AzureSdkCredential(DeferredCredential):
 
     def __init__(
         self,
-        scope: AzureSdkCredentialScope,
+        scope: AzureSdkCredentialScope = AzureSdkCredentialScope.DEFAULT,
         *,
-        skip_confirmation: bool,
+        skip_confirmation: bool = False,
     ) -> None:
         super().__init__(scopes=[scope.value], skip_confirmation=skip_confirmation)
 
@@ -157,10 +157,10 @@ class GraphApiCredential(DeferredCredential):
 
     def __init__(
         self,
-        scopes: Sequence[str],
         tenant_id: str,
         *,
-        skip_confirmation: bool,
+        scopes: Sequence[str] = [],
+        skip_confirmation: bool = False,
     ) -> None:
         super().__init__(
             scopes=scopes, tenant_id=tenant_id, skip_confirmation=skip_confirmation

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -71,7 +71,9 @@ class GraphApi:
         disable_logging: bool = False,
     ) -> "GraphApi":
         return cls(
-            credential=GraphApiCredential(tenant_id, scopes),
+            credential=GraphApiCredential(
+                scopes, tenant_id, confirm_credentials=(not disable_logging)
+            ),
             disable_logging=disable_logging,
         )
 

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -72,7 +72,7 @@ class GraphApi:
     ) -> "GraphApi":
         return cls(
             credential=GraphApiCredential(
-                scopes, tenant_id, confirm_credentials=(not disable_logging)
+                scopes, tenant_id, skip_confirmation=disable_logging
             ),
             disable_logging=disable_logging,
         )

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -72,7 +72,7 @@ class GraphApi:
     ) -> "GraphApi":
         return cls(
             credential=GraphApiCredential(
-                scopes, tenant_id, skip_confirmation=disable_logging
+                scopes=scopes, tenant_id=tenant_id, skip_confirmation=disable_logging
             ),
             disable_logging=disable_logging,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from pytest import fixture
 
 import data_safe_haven.config.context_manager as context_mod
 import data_safe_haven.logging.logger
+from data_safe_haven import console
 from data_safe_haven.config import (
     Context,
     ContextManager,
@@ -231,6 +232,24 @@ def mock_azuresdk_remove_blob(mocker):
         AzureSdk,
         "remove_blob",
         return_value=None,
+    )
+
+
+@fixture
+def mock_confirm_no(mocker):
+    return mocker.patch.object(
+        console,
+        "confirm",
+        return_value=False,
+    )
+
+
+@fixture
+def mock_confirm_yes(mocker):
+    return mocker.patch.object(
+        console,
+        "confirm",
+        return_value=True,
     )
 
 

--- a/tests/external/api/test_credentials.py
+++ b/tests/external/api/test_credentials.py
@@ -16,7 +16,7 @@ class TestDeferredCredential:
     def test_decode_token_error(
         self, mock_azureclicredential_get_token_invalid  # noqa: ARG002
     ):
-        credential = AzureSdkCredential()
+        credential = AzureSdkCredential(skip_confirmation=True)
         with pytest.raises(
             DataSafeHavenAzureError,
             match="Error getting account information from Azure CLI.",
@@ -26,11 +26,11 @@ class TestDeferredCredential:
 
 class TestAzureSdkCredential:
     def test_get_credential(self, mock_azureclicredential_get_token):  # noqa: ARG002
-        credential = AzureSdkCredential()
+        credential = AzureSdkCredential(skip_confirmation=True)
         assert isinstance(credential.get_credential(), AzureCliCredential)
 
     def test_get_token(self, mock_azureclicredential_get_token):  # noqa: ARG002
-        credential = AzureSdkCredential()
+        credential = AzureSdkCredential(skip_confirmation=True)
         assert isinstance(credential.token, str)
 
     def test_decode_token(
@@ -38,7 +38,7 @@ class TestAzureSdkCredential:
         request,
         mock_azureclicredential_get_token,  # noqa: ARG002
     ):
-        credential = AzureSdkCredential()
+        credential = AzureSdkCredential(skip_confirmation=True)
         decoded = credential.decode_token(credential.token)
         assert decoded["name"] == "username"
         assert decoded["oid"] == request.config.guid_user
@@ -65,7 +65,9 @@ class TestGraphApiCredential:
             f_auth.write(serialised_record)
 
         # Get a credential
-        credential = GraphApiCredential(request.config.guid_tenant)
+        credential = GraphApiCredential(
+            request.config.guid_tenant, skip_confirmation=True
+        )
         credential.get_credential()
 
         # Remove the authentication record
@@ -78,7 +80,9 @@ class TestGraphApiCredential:
         request,
         mock_graphapicredential_get_token,  # noqa: ARG002
     ):
-        credential = GraphApiCredential(request.config.guid_tenant)
+        credential = GraphApiCredential(
+            request.config.guid_tenant, skip_confirmation=True
+        )
         decoded = credential.decode_token(credential.token)
         assert decoded["scp"] == "GroupMember.Read.All User.Read.All"
         assert decoded["tid"] == request.config.guid_tenant
@@ -90,7 +94,9 @@ class TestGraphApiCredential:
         mock_devicecodecredential_get_token,  # noqa: ARG002
         tmp_config_dir,  # noqa: ARG002
     ):
-        credential = GraphApiCredential(request.config.guid_tenant)
+        credential = GraphApiCredential(
+            request.config.guid_tenant, skip_confirmation=True
+        )
         assert isinstance(credential.get_credential(), DeviceCodeCredential)
 
     def test_get_credential_callback(
@@ -100,7 +106,9 @@ class TestGraphApiCredential:
         mock_devicecodecredential_new,  # noqa: ARG002
         tmp_config_dir,  # noqa: ARG002
     ):
-        credential = GraphApiCredential(request.config.guid_tenant)
+        credential = GraphApiCredential(
+            request.config.guid_tenant, skip_confirmation=True
+        )
         credential.get_credential()
         captured = capsys.readouterr()
         cleaned_stdout = " ".join(captured.out.split())
@@ -115,5 +123,7 @@ class TestGraphApiCredential:
         mock_devicecodecredential_get_token,  # noqa: ARG002
         mock_graphapicredential_get_credential,  # noqa: ARG002
     ):
-        credential = GraphApiCredential(request.config.guid_tenant)
+        credential = GraphApiCredential(
+            request.config.guid_tenant, skip_confirmation=True
+        )
         assert isinstance(credential.token, str)


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->
n/a

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
Currently credential confirmation is written to the logs in unnecessary places (e.g. in the Pulumi output) and the user is not given a chance to check that the credentials are correct.

This adds:
- a confirmation prompt the first time a set of credentials are used
- suppresses credential information
  - after approval has been given
  - inside Pulumi (which is run as a separate process, so the previous class-variable solution was not working)

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
n/a

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
Tested on a fresh SRE deployment and on update