### PR TITLE
Reduce storage costs

### DIFF
--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -57,7 +57,7 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
     admin_ip_addresses: list[IpAddress] = []
     databases: UniqueList[DatabaseSystem] = []
     data_provider_ip_addresses: list[IpAddress] = []
-    remote_desktop: ConfigSubsectionRemoteDesktopOpts = Field(
+    remote_desktop: ConfigSubsectionRemoteDesktopOpts = Field(  # type: ignore
         ..., default_factory=ConfigSubsectionRemoteDesktopOpts
     )
     research_user_ip_addresses: list[IpAddress] = []

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -46,8 +46,8 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
 
 
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
-    home: AzurePremiumFileShareSize = 100
-    shared: AzurePremiumFileShareSize = 100
+    home: AzurePremiumFileShareSize
+    shared: AzurePremiumFileShareSize
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -44,6 +44,11 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
     allow_paste: bool = False
 
 
+class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
+    home: int = 50
+    shared: int = 50
+
+
 class ConfigSectionSRE(BaseModel, validate_assignment=True):
     admin_email_address: EmailAddress
     admin_ip_addresses: list[IpAddress] = Field(..., default_factory=list[IpAddress])
@@ -58,6 +63,9 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
     )
     research_user_ip_addresses: list[IpAddress] = Field(
         ..., default_factory=list[IpAddress]
+    )
+    storage_quota_gb: ConfigSubsectionStorageQuotaGB = Field(
+        ..., default_factory=ConfigSubsectionStorageQuotaGB
     )
     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE
     timezone: TimeZone = "Etc/UTC"

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from data_safe_haven.types import (
     AzureLocation,
+    AzurePremiumFileShareSize,
     AzureVmSku,
     DatabaseSystem,
     EmailAddress,
@@ -45,8 +46,8 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
 
 
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
-    home: int = 50
-    shared: int = 50
+    home: AzurePremiumFileShareSize = 100
+    shared: AzurePremiumFileShareSize = 100
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ipaddress import ip_network
 from itertools import combinations
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, field_validator
 
 from data_safe_haven.types import (
     AzureLocation,
@@ -41,8 +41,8 @@ class ConfigSectionSHM(BaseModel, validate_assignment=True):
 
 
 class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
-    allow_copy: bool = False
-    allow_paste: bool = False
+    allow_copy: bool
+    allow_paste: bool
 
 
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
@@ -57,9 +57,7 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
     admin_ip_addresses: list[IpAddress] = []
     databases: UniqueList[DatabaseSystem] = []
     data_provider_ip_addresses: list[IpAddress] = []
-    remote_desktop: ConfigSubsectionRemoteDesktopOpts = Field(  # type: ignore
-        ..., default_factory=ConfigSubsectionRemoteDesktopOpts
-    )
+    remote_desktop: ConfigSubsectionRemoteDesktopOpts
     research_user_ip_addresses: list[IpAddress] = []
     storage_quota_gb: ConfigSubsectionStorageQuotaGB
     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -51,26 +51,20 @@ class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):
+    # Mutable objects can be used as default arguments in Pydantic:
+    # https://docs.pydantic.dev/latest/concepts/models/#fields-with-non-hashable-default-values
     admin_email_address: EmailAddress
-    admin_ip_addresses: list[IpAddress] = Field(..., default_factory=list[IpAddress])
-    databases: UniqueList[DatabaseSystem] = Field(
-        ..., default_factory=list[DatabaseSystem]
-    )
-    data_provider_ip_addresses: list[IpAddress] = Field(
-        ..., default_factory=list[IpAddress]
-    )
+    admin_ip_addresses: list[IpAddress] = []
+    databases: UniqueList[DatabaseSystem] = []
+    data_provider_ip_addresses: list[IpAddress] = []
     remote_desktop: ConfigSubsectionRemoteDesktopOpts = Field(
         ..., default_factory=ConfigSubsectionRemoteDesktopOpts
     )
-    research_user_ip_addresses: list[IpAddress] = Field(
-        ..., default_factory=list[IpAddress]
-    )
-    storage_quota_gb: ConfigSubsectionStorageQuotaGB = Field(
-        ..., default_factory=ConfigSubsectionStorageQuotaGB
-    )
+    research_user_ip_addresses: list[IpAddress] = []
+    storage_quota_gb: ConfigSubsectionStorageQuotaGB
     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE
     timezone: TimeZone = "Etc/UTC"
-    workspace_skus: list[AzureVmSku] = Field(..., default_factory=list[AzureVmSku])
+    workspace_skus: list[AzureVmSku] = []
 
     @field_validator(
         "admin_ip_addresses",

--- a/data_safe_haven/config/shm_config.py
+++ b/data_safe_haven/config/shm_config.py
@@ -27,8 +27,9 @@ class SHMConfig(AzureSerialisableModel):
     ) -> SHMConfig:
         """Construct an SHMConfig from arguments."""
         azure_sdk = AzureSdk(subscription_name=context.subscription_name)
-        admin_group_id = azure_sdk.entra_directory.get_id_from_groupname(
-            context.admin_group_name
+        admin_group_id = (
+            azure_sdk.entra_directory.get_id_from_groupname(context.admin_group_name)
+            or "admin-group-id-not-found"
         )
         return SHMConfig.model_construct(
             azure=ConfigSectionAzure.model_construct(

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -66,14 +66,14 @@ class SREConfig(AzureSerialisableModel):
                     "List of IP addresses belonging to data providers"
                 ],
                 remote_desktop=ConfigSubsectionRemoteDesktopOpts.model_construct(
-                    allow_copy="True/False: whether to allow copying text out of the environment",
-                    allow_paste="True/False: whether to allow pasting text into the environment",
+                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",
+                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",
                 ),
                 research_user_ip_addresses=["List of IP addresses belonging to users"],
                 software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",
                 storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
-                    home="Total size in GB across all home directories [default: 50].",
-                    shared="Total size in GB for the shared directories [default: 50].",
+                    home="Total size in GB across all home directories [minimum: 100, default: 100].",
+                    shared="Total size in GB for the shared directories [minimum: 100, default: 100].",
                 ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -61,19 +61,19 @@ class SREConfig(AzureSerialisableModel):
             sre=ConfigSectionSRE.model_construct(
                 admin_email_address="Email address shared by all administrators",
                 admin_ip_addresses=["List of IP addresses belonging to administrators"],
-                databases=["List of database systems to deploy"],
+                databases=["List of database systems to deploy"],  # type:ignore
                 data_provider_ip_addresses=[
                     "List of IP addresses belonging to data providers"
                 ],
                 remote_desktop=ConfigSubsectionRemoteDesktopOpts.model_construct(
-                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",
-                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",
+                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",  # type:ignore
+                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",  # type:ignore
                 ),
                 research_user_ip_addresses=["List of IP addresses belonging to users"],
-                software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",
+                software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",  # type:ignore
                 storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
-                    home="Total size in GiB across all home directories [minimum: 100].",
-                    shared="Total size in GiB for the shared directories [minimum: 100].",
+                    home="Total size in GiB across all home directories [minimum: 100].",  # type:ignore
+                    shared="Total size in GiB for the shared directories [minimum: 100].",  # type:ignore
                 ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -72,8 +72,8 @@ class SREConfig(AzureSerialisableModel):
                 research_user_ip_addresses=["List of IP addresses belonging to users"],
                 software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",
                 storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
-                    home="Total size in GB across all home directories [minimum: 100, default: 100].",
-                    shared="Total size in GB for the shared directories [minimum: 100, default: 100].",
+                    home="Total size in GiB across all home directories [minimum: 100].",
+                    shared="Total size in GiB for the shared directories [minimum: 100].",
                 ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -13,6 +13,7 @@ from .config_sections import (
     ConfigSectionDockerHub,
     ConfigSectionSRE,
     ConfigSubsectionRemoteDesktopOpts,
+    ConfigSubsectionStorageQuotaGB,
 )
 
 
@@ -70,6 +71,10 @@ class SREConfig(AzureSerialisableModel):
                 ),
                 research_user_ip_addresses=["List of IP addresses belonging to users"],
                 software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",
+                storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
+                    home="Total size in GB across all home directories [default: 50].",
+                    shared="Total size in GB for the shared directories [default: 50].",
+                ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[
                     "List of Azure VM SKUs that will be used for data analysis."

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -66,8 +66,8 @@ class SREConfig(AzureSerialisableModel):
                     "List of IP addresses belonging to data providers"
                 ],
                 remote_desktop=ConfigSubsectionRemoteDesktopOpts.model_construct(
-                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",  # type:ignore
-                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",  # type:ignore
+                    allow_copy="True/False: whether to allow copying text out of the environment.",  # type:ignore
+                    allow_paste="True/False: whether to allow pasting text into the environment.",  # type:ignore
                 ),
                 research_user_ip_addresses=["List of IP addresses belonging to users"],
                 software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",  # type:ignore

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -181,6 +181,8 @@ class DeclarativeSRE:
                 location=self.config.azure.location,
                 resource_group=resource_group,
                 sre_fqdn=networking.sre_fqdn,
+                storage_quota_gb_home=self.config.sre.storage_quota_gb.home,
+                storage_quota_gb_shared=self.config.sre.storage_quota_gb.shared,
                 subnet_data_configuration=networking.subnet_data_configuration,
                 subnet_data_desired_state=networking.subnet_data_desired_state,
                 subnet_data_private=networking.subnet_data_private,

--- a/data_safe_haven/infrastructure/programs/sre/apt_proxy_server.py
+++ b/data_safe_haven/infrastructure/programs/sre/apt_proxy_server.py
@@ -58,7 +58,7 @@ class SREAptProxyServerComponent(ComponentResource):
         # Define configuration file shares
         file_share_apt_proxy_server = storage.FileShare(
             f"{self._name}_file_share_apt_proxy_server",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="apt-proxy-server",

--- a/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
+++ b/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
@@ -60,7 +60,7 @@ class SREClamAVMirrorComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="clamav-mirror",
-            share_quota=1,
+            share_quota=2,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
+++ b/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
@@ -56,7 +56,7 @@ class SREClamAVMirrorComponent(ComponentResource):
         # Define configuration file shares
         file_share_clamav_mirror = storage.FileShare(
             f"{self._name}_file_share_clamav_mirror",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="clamav-mirror",

--- a/data_safe_haven/infrastructure/programs/sre/data.py
+++ b/data_safe_haven/infrastructure/programs/sre/data.py
@@ -377,6 +377,7 @@ class SREDataComponent(ComponentResource):
                 f"{''.join(truncate_tokens(stack_name.split('-'), 14))}configdata"
             )[:24],
             kind=storage.Kind.STORAGE_V2,
+            large_file_shares_state=storage.LargeFileSharesState.DISABLED,
             location=props.location,
             minimum_tls_version=storage.MinimumTlsVersion.TLS1_2,
             network_rule_set=storage.NetworkRuleSetArgs(

--- a/data_safe_haven/infrastructure/programs/sre/data.py
+++ b/data_safe_haven/infrastructure/programs/sre/data.py
@@ -53,6 +53,8 @@ class SREDataProps:
         location: Input[str],
         resource_group: Input[resources.ResourceGroup],
         sre_fqdn: Input[str],
+        storage_quota_gb_home: Input[int],
+        storage_quota_gb_shared: Input[int],
         subnet_data_configuration: Input[network.GetSubnetResult],
         subnet_data_desired_state: Input[network.GetSubnetResult],
         subnet_data_private: Input[network.GetSubnetResult],
@@ -79,6 +81,8 @@ class SREDataProps:
             get_name_from_rg
         )
         self.sre_fqdn = sre_fqdn
+        self.storage_quota_gb_home = storage_quota_gb_home
+        self.storage_quota_gb_shared = storage_quota_gb_shared
         self.subnet_data_configuration_id = Output.from_input(
             subnet_data_configuration
         ).apply(get_id_from_subnet)
@@ -833,7 +837,7 @@ class SREDataComponent(ComponentResource):
             # Squashing prevents root from creating user home directories
             root_squash=storage.RootSquashType.NO_ROOT_SQUASH,
             share_name="home",
-            share_quota=1024,
+            share_quota=props.storage_quota_gb_home,
             signed_identifiers=[],
             opts=ResourceOptions.merge(
                 child_opts, ResourceOptions(parent=storage_account_data_private_user)
@@ -847,7 +851,7 @@ class SREDataComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             root_squash=storage.RootSquashType.ROOT_SQUASH,
             share_name="shared",
-            share_quota=1024,
+            share_quota=props.storage_quota_gb_shared,
             signed_identifiers=[],
             opts=ResourceOptions.merge(
                 child_opts, ResourceOptions(parent=storage_account_data_private_user)

--- a/data_safe_haven/infrastructure/programs/sre/data.py
+++ b/data_safe_haven/infrastructure/programs/sre/data.py
@@ -400,7 +400,7 @@ class SREDataComponent(ComponentResource):
                 ],
             ),
             resource_group_name=props.resource_group_name,
-            sku=storage.SkuArgs(name=storage.SkuName.STANDARD_GRS),
+            sku=storage.SkuArgs(name=storage.SkuName.STANDARD_LRS),
             opts=child_opts,
             tags=child_tags,
         )

--- a/data_safe_haven/infrastructure/programs/sre/data.py
+++ b/data_safe_haven/infrastructure/programs/sre/data.py
@@ -795,6 +795,8 @@ class SREDataComponent(ComponentResource):
         # - This holds the /home and /shared containers that are mounted by workspaces
         # - Azure Files has better NFS support but cannot be accessed with Azure Storage Explorer
         # - Allows root-squashing to be configured
+        # From https://learn.microsoft.com/en-us/azure/storage/files/files-nfs-protocol
+        # - premium file shares are required
         storage_account_data_private_user = storage.StorageAccount(
             f"{self._name}_storage_account_data_private_user",
             access_tier=storage.AccessTier.COOL,

--- a/data_safe_haven/infrastructure/programs/sre/gitea_server.py
+++ b/data_safe_haven/infrastructure/programs/sre/gitea_server.py
@@ -79,7 +79,7 @@ class SREGiteaServerComponent(ComponentResource):
         # Define configuration file shares
         file_share_gitea_caddy = storage.FileShare(
             f"{self._name}_file_share_gitea_caddy",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="gitea-caddy",
@@ -89,7 +89,7 @@ class SREGiteaServerComponent(ComponentResource):
         )
         file_share_gitea_gitea = storage.FileShare(
             f"{self._name}_file_share_gitea_gitea",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="gitea-gitea",

--- a/data_safe_haven/infrastructure/programs/sre/hedgedoc_server.py
+++ b/data_safe_haven/infrastructure/programs/sre/hedgedoc_server.py
@@ -82,7 +82,7 @@ class SREHedgeDocServerComponent(ComponentResource):
         # Define configuration file shares
         file_share_hedgedoc_caddy = storage.FileShare(
             f"{self._name}_file_share_hedgedoc_caddy",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="hedgedoc-caddy",

--- a/data_safe_haven/infrastructure/programs/sre/identity.py
+++ b/data_safe_haven/infrastructure/programs/sre/identity.py
@@ -73,7 +73,7 @@ class SREIdentityComponent(ComponentResource):
         # Define configuration file share
         file_share = storage.FileShare(
             f"{self._name}_file_share",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="identity-redis",

--- a/data_safe_haven/infrastructure/programs/sre/identity.py
+++ b/data_safe_haven/infrastructure/programs/sre/identity.py
@@ -77,7 +77,7 @@ class SREIdentityComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="identity-redis",
-            share_quota=5,
+            share_quota=1,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/remote_desktop.py
+++ b/data_safe_haven/infrastructure/programs/sre/remote_desktop.py
@@ -133,7 +133,7 @@ class SRERemoteDesktopComponent(ComponentResource):
         # Define configuration file shares
         file_share = storage.FileShare(
             f"{self._name}_file_share",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="remote-desktop-caddy",

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -87,7 +87,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus",
-            share_quota=5,
+            share_quota=2,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -73,7 +73,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
         # Define configuration file shares
         file_share_caddy = storage.FileShare(
             f"{self._name}_file_share_caddy",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-caddy",
@@ -83,7 +83,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
         )
         file_share_nexus = storage.FileShare(
             f"{self._name}_file_share_nexus",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus",
@@ -93,7 +93,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
         )
         file_share_nexus_allowlists = storage.FileShare(
             f"{self._name}_file_share_nexus_allowlists",
-            access_tier=storage.ShareAccessTier.COOL,
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus-allowlists",

--- a/data_safe_haven/serialisers/yaml_serialisable_model.py
+++ b/data_safe_haven/serialisers/yaml_serialisable_model.py
@@ -8,6 +8,7 @@ import yaml
 from pydantic import BaseModel, ValidationError
 
 from data_safe_haven.exceptions import DataSafeHavenConfigError, DataSafeHavenTypeError
+from data_safe_haven.logging import get_logger
 from data_safe_haven.types import PathType
 
 T = TypeVar("T", bound="YAMLSerialisableModel")
@@ -47,6 +48,14 @@ class YAMLSerialisableModel(BaseModel, validate_assignment=True):
         try:
             return cls.model_validate(settings_dict)
         except ValidationError as exc:
+            logger = get_logger()
+            logger.error(
+                f"Found {exc.error_count()} validation errors when trying to load {cls.config_type}."
+            )
+            for error in exc.errors():
+                logger.error(
+                    f"[red]{'.'.join(error.get('loc', []))}: {error.get('input', '')}[/] - {error.get('msg', '')}"
+                )
             msg = f"Could not load {cls.config_type} configuration."
             raise DataSafeHavenTypeError(msg) from exc
 

--- a/data_safe_haven/serialisers/yaml_serialisable_model.py
+++ b/data_safe_haven/serialisers/yaml_serialisable_model.py
@@ -54,7 +54,7 @@ class YAMLSerialisableModel(BaseModel, validate_assignment=True):
             )
             for error in exc.errors():
                 logger.error(
-                    f"[red]{'.'.join(error.get('loc', []))}: {error.get('input', '')}[/] - {error.get('msg', '')}"
+                    f"[red]{'.'.join(map(str, error.get('loc', [])))}: {error.get('input', '')}[/] - {error.get('msg', '')}"
                 )
             msg = f"Could not load {cls.config_type} configuration."
             raise DataSafeHavenTypeError(msg) from exc

--- a/data_safe_haven/types/__init__.py
+++ b/data_safe_haven/types/__init__.py
@@ -1,5 +1,6 @@
 from .annotated_types import (
     AzureLocation,
+    AzurePremiumFileShareSize,
     AzureSubscriptionName,
     AzureVmSku,
     EmailAddress,
@@ -27,6 +28,7 @@ from .types import PathType
 __all__ = [
     "AzureDnsZoneNames",
     "AzureLocation",
+    "AzurePremiumFileShareSize",
     "AzureSdkCredentialScope",
     "AzureSubscriptionName",
     "AzureVmSku",

--- a/data_safe_haven/types/annotated_types.py
+++ b/data_safe_haven/types/annotated_types.py
@@ -1,18 +1,20 @@
 from collections.abc import Hashable
 from typing import Annotated, TypeAlias, TypeVar
 
+from annotated_types import Ge
 from pydantic import Field
 from pydantic.functional_validators import AfterValidator
 
 from data_safe_haven import validators
 
+AzureLocation = Annotated[str, AfterValidator(validators.azure_location)]
+AzurePremiumFileShareSize = Annotated[int, Ge(100)]
 AzureShortName = Annotated[str, Field(min_length=1, max_length=24)]
 AzureSubscriptionName = Annotated[
     str,
     Field(min_length=1, max_length=80),
     AfterValidator(validators.azure_subscription_name),
 ]
-AzureLocation = Annotated[str, AfterValidator(validators.azure_location)]
 AzureVmSku = Annotated[str, AfterValidator(validators.azure_vm_sku)]
 EmailAddress = Annotated[str, AfterValidator(validators.email_address)]
 EntraGroupName = Annotated[str, AfterValidator(validators.entra_group_name)]

--- a/out.log
+++ b/out.log
@@ -1,0 +1,211 @@
+diff --git a/data_safe_haven/config/config_sections.py b/data_safe_haven/config/config_sections.py
+index 2d9399e77..e0c4fee7e 100644
+--- a/data_safe_haven/config/config_sections.py
++++ b/data_safe_haven/config/config_sections.py
+@@ -5,7 +5,7 @@ from __future__ import annotations
+ from ipaddress import ip_network
+ from itertools import combinations
+
+-from pydantic import BaseModel, Field, field_validator
++from pydantic import BaseModel, field_validator
+
+ from data_safe_haven.types import (
+     AzureLocation,
+@@ -41,8 +41,8 @@ class ConfigSectionSHM(BaseModel, validate_assignment=True):
+
+
+ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
+-    allow_copy: bool = False
+-    allow_paste: bool = False
++    allow_copy: bool
++    allow_paste: bool
+
+
+ class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
+@@ -55,9 +55,7 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
+     admin_ip_addresses: list[IpAddress] = []
+     databases: UniqueList[DatabaseSystem] = []
+     data_provider_ip_addresses: list[IpAddress] = []
+-    remote_desktop: ConfigSubsectionRemoteDesktopOpts = Field(
+-        ..., default_factory=ConfigSubsectionRemoteDesktopOpts
+-    )
++    remote_desktop: ConfigSubsectionRemoteDesktopOpts
+     research_user_ip_addresses: list[IpAddress] = []
+     storage_quota_gb: ConfigSubsectionStorageQuotaGB
+     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE
+diff --git a/data_safe_haven/config/sre_config.py b/data_safe_haven/config/sre_config.py
+index fcbb86f31..86a1ba072 100644
+--- a/data_safe_haven/config/sre_config.py
++++ b/data_safe_haven/config/sre_config.py
+@@ -61,19 +61,19 @@ class SREConfig(AzureSerialisableModel):
+             sre=ConfigSectionSRE.model_construct(
+                 admin_email_address="Email address shared by all administrators",
+                 admin_ip_addresses=["List of IP addresses belonging to administrators"],
+                 databases=["List of database systems to deploy"],  # type:ignore
+                 data_provider_ip_addresses=[
+                     "List of IP addresses belonging to data providers"
+                 ],
+                 remote_desktop=ConfigSubsectionRemoteDesktopOpts.model_construct(
+-                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",
+-                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",
++                    allow_copy="True/False: whether to allow copying text out of the environment [default: False].",  # type:ignore
++                    allow_paste="True/False: whether to allow pasting text into the environment [default: False].",  # type:ignore
+                 ),
+                 research_user_ip_addresses=["List of IP addresses belonging to users"],
+-                software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",
++                software_packages="Which Python/R packages to allow users to install: [any/pre-approved/none]",  # type:ignore
+                 storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
+-                    home="Total size in GiB across all home directories [minimum: 100].",
+-                    shared="Total size in GiB for the shared directories [minimum: 100].",
++                    home="Total size in GiB across all home directories [minimum: 100].",  # type:ignore
++                    shared="Total size in GiB for the shared directories [minimum: 100].",  # type:ignore
+                 ),
+                 timezone="Timezone in pytz format (eg. Europe/London)",
+                 workspace_skus=[
+diff --git a/pyproject.toml b/pyproject.toml
+index 115fa5f42..bf4fcec5b 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -142,6 +142,7 @@ path = "data_safe_haven/version.py"
+ disallow_subclassing_any = false  # allow subclassing of types from third-party libraries
+ files = "data_safe_haven"         # run mypy over this directory
+ mypy_path = "typings"             # use this directory for stubs
++plugins = "pydantic.mypy"         # enable the pydantic plugin
+ strict = true                     # enable all optional error checking flags
+
+ [[tool.mypy.overrides]]
+diff --git a/tests/config/test_config_sections.py b/tests/config/test_config_sections.py
+index cc6dd0d33..3488e00ba 100644
+--- a/tests/config/test_config_sections.py
++++ b/tests/config/test_config_sections.py
+@@ -7,6 +7,7 @@ from data_safe_haven.config.config_sections import (
+     ConfigSectionSHM,
+     ConfigSectionSRE,
+     ConfigSubsectionRemoteDesktopOpts,
++    ConfigSubsectionStorageQuotaGB,
+ )
+ from data_safe_haven.types import DatabaseSystem, SoftwarePackageCategory
+
+@@ -111,7 +112,9 @@ class TestConfigSectionSHM:
+
+ class TestConfigSectionSRE:
+     def test_constructor(
+-        self, remote_desktop_config: ConfigSubsectionRemoteDesktopOpts
++        self,
++        remote_desktop_config: ConfigSubsectionRemoteDesktopOpts,
++        config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
+     ) -> None:
+         sre_config = ConfigSectionSRE(
+             admin_email_address="admin@example.com",
+@@ -122,6 +125,7 @@ class TestConfigSectionSRE:
+             workspace_skus=["Standard_D2s_v4"],
+             research_user_ip_addresses=["3.4.5.6"],
+             software_packages=SoftwarePackageCategory.ANY,
++            storage_quota_gb=config_subsection_storage_quota_gb,
+             timezone="Australia/Perth",
+         )
+         assert sre_config.admin_email_address == "admin@example.com"
+@@ -132,12 +136,13 @@ class TestConfigSectionSRE:
+         assert sre_config.workspace_skus[0] == "Standard_D2s_v4"
+         assert sre_config.research_user_ip_addresses[0] == "3.4.5.6/32"
+         assert sre_config.software_packages == SoftwarePackageCategory.ANY
++        assert sre_config.storage_quota_gb == config_subsection_storage_quota_gb
+         assert sre_config.timezone == "Australia/Perth"
+
+     def test_constructor_defaults(
+-        self, remote_desktop_config: ConfigSubsectionRemoteDesktopOpts
++        self, remote_desktop_config: ConfigSubsectionRemoteDesktopOpts, config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
+     ) -> None:
+-        sre_config = ConfigSectionSRE(admin_email_address="admin@example.com")
++        sre_config = ConfigSectionSRE(admin_email_address="admin@example.com", remote_desktop_config=remote_desktop_config, storage_quota_gb=config_subsection_storage_quota_gb)
+         assert sre_config.admin_email_address == "admin@example.com"
+         assert sre_config.admin_ip_addresses == []
+         assert sre_config.databases == []
+@@ -193,12 +198,6 @@ class TestConfigSubsectionRemoteDesktopOpts:
+     def test_constructor(self) -> None:
+         ConfigSubsectionRemoteDesktopOpts(allow_copy=True, allow_paste=True)
+
+-    def test_constructor_defaults(self) -> None:
+-        remote_desktop_config = ConfigSubsectionRemoteDesktopOpts()
+-        assert not all(
+-            (remote_desktop_config.allow_copy, remote_desktop_config.allow_paste)
+-        )
+-
+     def test_constructor_invalid_allow_copy(self) -> None:
+         with pytest.raises(
+             ValueError,
+@@ -208,3 +207,28 @@ class TestConfigSubsectionRemoteDesktopOpts:
+                 allow_copy=True,
+                 allow_paste="not a bool",
+             )
++
++
++class TestConfigSubsectionStorageQuotaGB:
++    def test_constructor(self) -> None:
++        ConfigSubsectionStorageQuotaGB(home=100, shared=100)
++
++    def test_constructor_invalid_type(self) -> None:
++        with pytest.raises(
++            ValueError,
++            match=r"1 validation error for ConfigSubsectionStorageQuotaGB\nallow_paste\n  Input should be a valid boolean",
++        ):
++            ConfigSubsectionStorageQuotaGB(
++                home=100,
++                shared="not a bool",
++            )
++
++    def test_constructor_invalid_value(self) -> None:
++        with pytest.raises(
++            ValueError,
++            match=r"1 validation error for ConfigSubsectionStorageQuotaGB\nallow_paste\n  Input should be a valid boolean",
++        ):
++            ConfigSubsectionStorageQuotaGB(
++                home=50,
++                shared=100,
++            )
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 1acd447ee..c2853c989 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -25,6 +25,7 @@ from data_safe_haven.config.config_sections import (
+     ConfigSectionSHM,
+     ConfigSectionSRE,
+     ConfigSubsectionRemoteDesktopOpts,
++    ConfigSubsectionStorageQuotaGB,
+ )
+ from data_safe_haven.exceptions import DataSafeHavenAzureError
+ from data_safe_haven.external import AzureSdk, PulumiAccount
+@@ -75,14 +76,23 @@ def config_section_dockerhub() -> ConfigSectionDockerHub:
+
+
+ @fixture
+-def config_section_sre() -> ConfigSectionSRE:
++def config_section_sre(
++    remote_desktop_config, config_subsection_storage_quota_gb
++) -> ConfigSectionSRE:
+     return ConfigSectionSRE(
+         admin_email_address="admin@example.com",
+         admin_ip_addresses=["1.2.3.4"],
++        remote_desktop=remote_desktop_config,
++        storage_quota_gb=config_subsection_storage_quota_gb,
+         timezone="Europe/London",
+     )
+
+
++@fixture
++def config_subsection_storage_quota_gb() -> ConfigSubsectionStorageQuotaGB:
++    return ConfigSubsectionStorageQuotaGB(home=100, shared=100)
++
++
+ @fixture
+ def context(context_dict):
+     return Context(**context_dict)
+@@ -385,7 +395,7 @@ def pulumi_config_yaml() -> str:
+
+ @fixture
+ def remote_desktop_config() -> ConfigSubsectionRemoteDesktopOpts:
+-    return ConfigSubsectionRemoteDesktopOpts()
++    return ConfigSubsectionRemoteDesktopOpts(allow_copy=False, allow_paste=False)
+
+
+ @fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ path = "data_safe_haven/version.py"
 disallow_subclassing_any = false  # allow subclassing of types from third-party libraries
 files = "data_safe_haven"         # run mypy over this directory
 mypy_path = "typings"             # use this directory for stubs
+plugins = "pydantic.mypy"         # enable the pydantic plugin
 strict = true                     # enable all optional error checking flags
 
 [[tool.mypy.overrides]]

--- a/tests/config/test_config_sections.py
+++ b/tests/config/test_config_sections.py
@@ -7,6 +7,7 @@ from data_safe_haven.config.config_sections import (
     ConfigSectionSHM,
     ConfigSectionSRE,
     ConfigSubsectionRemoteDesktopOpts,
+    ConfigSubsectionStorageQuotaGB,
 )
 from data_safe_haven.types import DatabaseSystem, SoftwarePackageCategory
 
@@ -111,7 +112,9 @@ class TestConfigSectionSHM:
 
 class TestConfigSectionSRE:
     def test_constructor(
-        self, remote_desktop_config: ConfigSubsectionRemoteDesktopOpts
+        self,
+        remote_desktop_config: ConfigSubsectionRemoteDesktopOpts,
+        config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
     ) -> None:
         sre_config = ConfigSectionSRE(
             admin_email_address="admin@example.com",
@@ -122,6 +125,7 @@ class TestConfigSectionSRE:
             workspace_skus=["Standard_D2s_v4"],
             research_user_ip_addresses=["3.4.5.6"],
             software_packages=SoftwarePackageCategory.ANY,
+            storage_quota_gb=config_subsection_storage_quota_gb,
             timezone="Australia/Perth",
         )
         assert sre_config.admin_email_address == "admin@example.com"
@@ -132,12 +136,18 @@ class TestConfigSectionSRE:
         assert sre_config.workspace_skus[0] == "Standard_D2s_v4"
         assert sre_config.research_user_ip_addresses[0] == "3.4.5.6/32"
         assert sre_config.software_packages == SoftwarePackageCategory.ANY
+        assert sre_config.storage_quota_gb == config_subsection_storage_quota_gb
         assert sre_config.timezone == "Australia/Perth"
 
     def test_constructor_defaults(
-        self, remote_desktop_config: ConfigSubsectionRemoteDesktopOpts
+        self,
+        remote_desktop_config: ConfigSubsectionRemoteDesktopOpts,
+        config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
     ) -> None:
-        sre_config = ConfigSectionSRE(admin_email_address="admin@example.com")
+        sre_config = ConfigSectionSRE(
+            admin_email_address="admin@example.com",
+            storage_quota_gb=config_subsection_storage_quota_gb,
+        )
         assert sre_config.admin_email_address == "admin@example.com"
         assert sre_config.admin_ip_addresses == []
         assert sre_config.databases == []
@@ -207,4 +217,36 @@ class TestConfigSubsectionRemoteDesktopOpts:
             ConfigSubsectionRemoteDesktopOpts(
                 allow_copy=True,
                 allow_paste="not a bool",
+            )
+
+
+class TestConfigSubsectionStorageQuotaGB:
+    def test_constructor(self) -> None:
+        ConfigSubsectionStorageQuotaGB(home=100, shared=100)
+
+    def test_constructor_defaults(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"1 validation error for ConfigSubsectionStorageQuotaGB\nshared\n  Field required",
+        ):
+            ConfigSubsectionStorageQuotaGB(home=100)
+
+    def test_constructor_invalid_type(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"1 validation error for ConfigSubsectionStorageQuotaGB\nshared\n  Input should be a valid integer",
+        ):
+            ConfigSubsectionStorageQuotaGB(
+                home=100,
+                shared="not a bool",
+            )
+
+    def test_constructor_invalid_value(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"1 validation error for ConfigSubsectionStorageQuotaGB\nhome\n  Input should be greater than or equal to 100",
+        ):
+            ConfigSubsectionStorageQuotaGB(
+                home=50,
+                shared=100,
             )

--- a/tests/config/test_config_sections.py
+++ b/tests/config/test_config_sections.py
@@ -113,7 +113,7 @@ class TestConfigSectionSHM:
 class TestConfigSectionSRE:
     def test_constructor(
         self,
-        remote_desktop_config: ConfigSubsectionRemoteDesktopOpts,
+        config_subsection_remote_desktop: ConfigSubsectionRemoteDesktopOpts,
         config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
     ) -> None:
         sre_config = ConfigSectionSRE(
@@ -121,7 +121,7 @@ class TestConfigSectionSRE:
             admin_ip_addresses=["1.2.3.4"],
             databases=[DatabaseSystem.POSTGRESQL],
             data_provider_ip_addresses=["2.3.4.5"],
-            remote_desktop=remote_desktop_config,
+            remote_desktop=config_subsection_remote_desktop,
             workspace_skus=["Standard_D2s_v4"],
             research_user_ip_addresses=["3.4.5.6"],
             software_packages=SoftwarePackageCategory.ANY,
@@ -132,31 +132,33 @@ class TestConfigSectionSRE:
         assert sre_config.admin_ip_addresses[0] == "1.2.3.4/32"
         assert sre_config.databases[0] == DatabaseSystem.POSTGRESQL
         assert sre_config.data_provider_ip_addresses[0] == "2.3.4.5/32"
-        assert sre_config.remote_desktop == remote_desktop_config
-        assert sre_config.workspace_skus[0] == "Standard_D2s_v4"
+        assert sre_config.remote_desktop == config_subsection_remote_desktop
         assert sre_config.research_user_ip_addresses[0] == "3.4.5.6/32"
         assert sre_config.software_packages == SoftwarePackageCategory.ANY
         assert sre_config.storage_quota_gb == config_subsection_storage_quota_gb
         assert sre_config.timezone == "Australia/Perth"
+        assert sre_config.workspace_skus[0] == "Standard_D2s_v4"
 
     def test_constructor_defaults(
         self,
-        remote_desktop_config: ConfigSubsectionRemoteDesktopOpts,
+        config_subsection_remote_desktop: ConfigSubsectionRemoteDesktopOpts,
         config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
     ) -> None:
         sre_config = ConfigSectionSRE(
             admin_email_address="admin@example.com",
+            remote_desktop=config_subsection_remote_desktop,
             storage_quota_gb=config_subsection_storage_quota_gb,
         )
         assert sre_config.admin_email_address == "admin@example.com"
         assert sre_config.admin_ip_addresses == []
         assert sre_config.databases == []
         assert sre_config.data_provider_ip_addresses == []
-        assert sre_config.remote_desktop == remote_desktop_config
-        assert sre_config.workspace_skus == []
+        assert sre_config.remote_desktop == config_subsection_remote_desktop
         assert sre_config.research_user_ip_addresses == []
         assert sre_config.software_packages == SoftwarePackageCategory.NONE
+        assert sre_config.storage_quota_gb == config_subsection_storage_quota_gb
         assert sre_config.timezone == "Etc/UTC"
+        assert sre_config.workspace_skus == []
 
     def test_all_databases_must_be_unique(self) -> None:
         with pytest.raises(ValueError, match=r"All items must be unique."):
@@ -204,10 +206,11 @@ class TestConfigSubsectionRemoteDesktopOpts:
         ConfigSubsectionRemoteDesktopOpts(allow_copy=True, allow_paste=True)
 
     def test_constructor_defaults(self) -> None:
-        remote_desktop_config = ConfigSubsectionRemoteDesktopOpts()
-        assert not all(
-            (remote_desktop_config.allow_copy, remote_desktop_config.allow_paste)
-        )
+        with pytest.raises(
+            ValueError,
+            match=r"1 validation error for ConfigSubsectionRemoteDesktopOpts\nallow_copy\n  Field required",
+        ):
+            ConfigSubsectionRemoteDesktopOpts(allow_paste=False)
 
     def test_constructor_invalid_allow_copy(self) -> None:
         with pytest.raises(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -501,6 +501,9 @@ def sre_config_yaml(request):
             allow_paste: false
         research_user_ip_addresses: []
         software_packages: none
+        storage_quota_gb:
+            home: 100
+            shared: 100
         timezone: Europe/London
         workspace_skus: []
     """.replace(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from data_safe_haven.config.config_sections import (
     ConfigSectionSHM,
     ConfigSectionSRE,
     ConfigSubsectionRemoteDesktopOpts,
+    ConfigSubsectionStorageQuotaGB,
 )
 from data_safe_haven.exceptions import DataSafeHavenAzureError
 from data_safe_haven.external import AzureSdk, PulumiAccount
@@ -75,12 +76,21 @@ def config_section_dockerhub() -> ConfigSectionDockerHub:
 
 
 @fixture
-def config_section_sre() -> ConfigSectionSRE:
+def config_section_sre(
+    remote_desktop_config, config_subsection_storage_quota_gb
+) -> ConfigSectionSRE:
     return ConfigSectionSRE(
         admin_email_address="admin@example.com",
         admin_ip_addresses=["1.2.3.4"],
+        remote_desktop=remote_desktop_config,
+        storage_quota_gb=config_subsection_storage_quota_gb,
         timezone="Europe/London",
     )
+
+
+@fixture
+def config_subsection_storage_quota_gb() -> ConfigSubsectionStorageQuotaGB:
+    return ConfigSubsectionStorageQuotaGB(home=100, shared=100)
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,15 +77,20 @@ def config_section_dockerhub() -> ConfigSectionDockerHub:
 
 @fixture
 def config_section_sre(
-    remote_desktop_config, config_subsection_storage_quota_gb
+    config_subsection_remote_desktop, config_subsection_storage_quota_gb
 ) -> ConfigSectionSRE:
     return ConfigSectionSRE(
         admin_email_address="admin@example.com",
         admin_ip_addresses=["1.2.3.4"],
-        remote_desktop=remote_desktop_config,
+        remote_desktop=config_subsection_remote_desktop,
         storage_quota_gb=config_subsection_storage_quota_gb,
         timezone="Europe/London",
     )
+
+
+@fixture
+def config_subsection_remote_desktop() -> ConfigSubsectionRemoteDesktopOpts:
+    return ConfigSubsectionRemoteDesktopOpts(allow_copy=False, allow_paste=False)
 
 
 @fixture
@@ -391,11 +396,6 @@ def pulumi_config_yaml() -> str:
                 data-safe-haven:variable: -3
     """
     return yaml.dump(yaml.safe_load(content))
-
-
-@fixture
-def remote_desktop_config() -> ConfigSubsectionRemoteDesktopOpts:
-    return ConfigSubsectionRemoteDesktopOpts()
 
 
 @fixture


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on


<!--
List any other PRs that must be merged before this one
-->
n/a

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
Reduce storage costs by changing storage SKUs and quotas

- Reduce /home and /shared to the minimum size (100GiB)
    <img width="541" alt="Screenshot 2024-08-16 at 13 35 19" src="https://github.com/user-attachments/assets/31dd0cd2-2742-4694-b527-e0606c8a1867">
- Add a config option to set the quota for /home and /shared
- Move config file share to transaction-optimised storage

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Progress towards #2124

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
Test details below:

TL;DR: This change reduces daily costs for an idle SRE from ~£70 to ~£45 an ~35% decrease.

#### Wednesday August 14th (before changes made)

Daily(!) cost summary of all SHMs/SREs

<img width="1200" alt="Screenshot 2024-08-16 at 12 39 29" src="https://github.com/user-attachments/assets/293a701c-d3c3-445a-9d9b-4c964c75951a">

Resources in `sre-coral` costing more than £1.50 per day:

<img width="1200" alt="Screenshot 2024-08-16 at 12 40 27" src="https://github.com/user-attachments/assets/b505f849-a89f-4682-ae86-8f1b8b7ceaff">

<!--
#### Friday August 16th (coral deployed halfway through this day)

<img width="1200" alt="Screenshot 2024-08-16 at 16 33 16" src="https://github.com/user-attachments/assets/c9ac238d-248f-45cb-880c-fb16b3848dad">

<img width="1200" alt="Screenshot 2024-08-16 at 16 33 29" src="https://github.com/user-attachments/assets/edadc42c-e9b3-4152-8e23-131043217560">

Not a completely fair comparison as `coral` was only deployed partway through the day, but if we assume the firewall costs will be equivalent, then we need to multiply total cost here by ~6 giving an estimate of £36 for the day: an approximately **50% reduction** on the previous state.
-->

#### Sunday August 18th

**Note: this is a day when none of the SREs are being used: variations in costs will be due to different VM sizes/database deployments**

<img width="1200" alt="Screenshot 2024-08-19 at 09 42 39" src="https://github.com/user-attachments/assets/86d8ad7b-6dcc-4e37-8e7a-0fa3fff38eea">

<img width="1200" alt="Screenshot 2024-08-19 at 09 44 32" src="https://github.com/user-attachments/assets/792d9800-f714-4e5c-8f95-001861c91971">

- User data is at ~10% of a comparable SRE
- Config data is at ~15% of a comparable SRE