### PR TITLE
Reduce application gateway costs

### DIFF
--- a/.github/workflows/lint_code.yaml
+++ b/.github/workflows/lint_code.yaml
@@ -48,9 +48,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
       - name: Install requirements
         shell: bash
-        run: sudo gem install mdl
+        run: gem install mdl
       - name: Lint Markdown
         run: mdl --style .mdlstyle.rb .
 

--- a/data_safe_haven/infrastructure/programs/sre/application_gateway.py
+++ b/data_safe_haven/infrastructure/programs/sre/application_gateway.py
@@ -262,8 +262,8 @@ class SREApplicationGatewayComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             sku=network.ApplicationGatewaySkuArgs(
                 capacity=1,
-                name="Standard_v2",
-                tier="Standard_v2",
+                name="Basic",
+                tier="Basic",
             ),
             ssl_certificates=[
                 network.ApplicationGatewaySslCertificateArgs(

--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -17,6 +17,18 @@ $ hatch shell
 This ensures that you are using the intended version of Data Safe Haven with the correct set of dependencies.
 ::::
 
+::::{important}
+As the Basic Application Gateway is still in preview, you will need to run the following commands once per subscription:
+
+:::{code} shell
+$ az feature register --name "AllowApplicationGatewayBasicSku" \
+                      --namespace "Microsoft.Network" \
+                      --subscription NAME_OR_ID_OF_YOUR_SUBSCRIPTION
+$ az provider register --name Microsoft.Network
+:::
+
+::::
+
 ## Configuration
 
 Each project will have its own dedicated SRE.

--- a/tests/infrastructure/programs/sre/test_application_gateway.py
+++ b/tests/infrastructure/programs/sre/test_application_gateway.py
@@ -564,8 +564,8 @@ class TestSREApplicationGatewayComponent:
                 assert_equal,
                 network.outputs.ApplicationGatewaySkuResponse(
                     capacity=1,
-                    name="Standard_v2",
-                    tier="Standard_v2",
+                    name="Basic",
+                    tier="Basic",
                 ),
             ),
             run_with_unknowns=True,


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->
n/a

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
- Reduce Application Gateway costs by dropping to Basic SKU (currently in preview)
- This needs to be manually enabled by deployers on a per-subscription basis (instructions in docs)

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Progress towards #2124

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

<img width="781" alt="Screenshot 2024-08-19 at 09 49 36" src="https://github.com/user-attachments/assets/9b8d1d5f-031f-464e-89f0-fbe01531cd33">

<img width="778" alt="Screenshot 2024-08-19 at 09 49 50" src="https://github.com/user-attachments/assets/c3dd6ecb-8fbe-4d9c-a258-9313f5990325">

N.B. This only covers part of a day, but scaling up to `coral`s cost of £5.91 from yesterday gives:
- before change: £5.91
- after change: £2.51

so this reduces daily Application Gateway costs by ~55%