### PR TITLE
Update smoke tests for new mount locations

### DIFF
--- a/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/run_all_tests.bats
+++ b/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/run_all_tests.bats
@@ -42,20 +42,24 @@ check_db_credentials() {
 
 # Mounted drives
 # --------------
-@test "Mounted drives (/data)" {
-    run bash test_mounted_drives.sh -d data
+@test "Mounted drives (/mnt/input)" {
+    run bash test_mounted_drives.sh -d mnt/input
     [ "$status" -eq 0 ]
 }
 @test "Mounted drives (/home)" {
     run bash test_mounted_drives.sh -d home
     [ "$status" -eq 0 ]
 }
-@test "Mounted drives (/output)" {
-    run bash test_mounted_drives.sh -d output
+@test "Mounted drives (/mnt/output)" {
+    run bash test_mounted_drives.sh -d mnt/output
     [ "$status" -eq 0 ]
 }
-@test "Mounted drives (/shared)" {
-    run bash test_mounted_drives.sh -d shared
+@test "Mounted drives (/mnt/shared)" {
+    run bash test_mounted_drives.sh -d mnt/shared
+    [ "$status" -eq 0 ]
+}
+@test "Mounted drives (/var/local/desired_state)" {
+    run bash test_mounted_drives.sh -d var/local/desired_state
     [ "$status" -eq 0 ]
 }
 

--- a/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/run_all_tests.bats
+++ b/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/run_all_tests.bats
@@ -58,8 +58,8 @@ check_db_credentials() {
     run bash test_mounted_drives.sh -d mnt/shared
     [ "$status" -eq 0 ]
 }
-@test "Mounted drives (/var/local/desired_state)" {
-    run bash test_mounted_drives.sh -d var/local/desired_state
+@test "Mounted drives (/var/local/ansible)" {
+    run bash test_mounted_drives.sh -d var/local/ansible
     [ "$status" -eq 0 ]
 }
 

--- a/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/test_mounted_drives.sh
+++ b/data_safe_haven/resources/workspace/ansible/files/usr/local/smoke_tests/test_mounted_drives.sh
@@ -26,7 +26,7 @@ CAN_DELETE="$([[ "$(touch "${directory_path}/${testfile}" 2>&1 1>/dev/null && rm
 
 # Check that permissions are as expected for each directory
 case "$directory" in
-    data)
+    mnt/input)
         if [ "$CAN_CREATE" = 1 ]; then echo "Able to create files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_WRITE" = 1 ]; then echo "Able to write files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_DELETE" = 1 ]; then echo "Able to delete files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
@@ -38,16 +38,22 @@ case "$directory" in
         if [ "$CAN_DELETE" = 0 ]; then echo "Unable to delete files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         ;;
 
-    output)
+    mnt/output)
         if [ "$CAN_CREATE" = 0 ]; then echo "Unable to create files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_WRITE" = 0 ]; then echo "Unable to write files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_DELETE" = 0 ]; then echo "Unable to delete files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         ;;
 
-    shared)
+    mnt/shared)
         if [ "$CAN_CREATE" = 0 ]; then echo "Unable to create files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_WRITE" = 0 ]; then echo "Unable to write files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         if [ "$CAN_DELETE" = 0 ]; then echo "Unable to delete files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
+        ;;
+
+    var/local/ansible)
+        if [ "$CAN_CREATE" = 1 ]; then echo "Able to create files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
+        if [ "$CAN_WRITE" = 1 ]; then echo "Able to write files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
+        if [ "$CAN_DELETE" = 1 ]; then echo "Able to delete files in ${directory_path}!"; nfailed=$((nfailed + 1)); fi
         ;;
 
     *)


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested on a new deployment

```console
root@shm-daimyo-sre-hojo-vm-workspace-02:/usr/local/smoke_tests# ./run_all_tests.bats 
 ✓ Mounted drives (/mnt/input) 
 ✓ Mounted drives (/home) 
 ✓ Mounted drives (/mnt/output) 
 ✓ Mounted drives (/mnt/shared) 
 ✓ Mounted drives (/var/local/ansible) 
 ✓ Python package repository 
 ✓ R package repository 
 ✓ Python functionality 
 ✓ R functionality 
 ✓ MS SQL database (Python) 
 ✓ MS SQL database (R) 
 ✓ Postgres database (Python) 
 ✓ Postgres database (R) 

13 tests, 0 failures
```