### PR TITLE
Unchangable Pulumi workspace configuration

### DIFF
--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -286,12 +286,22 @@ class ProjectManager:
             raise DataSafeHavenPulumiError(msg) from exc
 
     def ensure_config(self, name: str, value: str, *, secret: bool) -> None:
-        """Ensure that config values have been set, setting them if they do not exist"""
+        """
+        Ensure that config values have been set.
+
+        Values will be set if they do not exist.
+
+        If the value is already set and does not match the `value` argument,
+        `DataSafeHavenPulumiError` will be raised.
+        """
         try:
             existing_value = self.stack.get_config(name).value
         except automation.CommandError:
+            # Set value if it does not already exist
             self.set_config(name, value, secret=secret)
 
+        # If the value does already exist, ensure it is consistent with the declared
+        # value
         if existing_value != value:
             msg = (
                 f"Unchangeable configuration option '{name}' not consistent, "

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -294,7 +294,7 @@ class ProjectManager:
 
         if existing_value != value:
             msg = (
-                f"Unchangeable configuration variable '{name}' not consistent, "
+                f"Unchangeable configuration option '{name}' not consistent, "
                 f"your configuration: '{value}', Pulumi workspace: '{existing_value}'."
             )
             raise DataSafeHavenPulumiError(msg)

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -288,7 +288,7 @@ class ProjectManager:
     def ensure_config(self, name: str, value: str, *, secret: bool) -> None:
         """Ensure that config values have been set, setting them if they do not exist"""
         try:
-            existing_value = self.stack.get_config(name)
+            existing_value = self.stack.get_config(name).value
         except automation.CommandError:
             self.set_config(name, value, secret=secret)
 

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -288,9 +288,16 @@ class ProjectManager:
     def ensure_config(self, name: str, value: str, *, secret: bool) -> None:
         """Ensure that config values have been set, setting them if they do not exist"""
         try:
-            self.stack.get_config(name)
+            existing_value = self.stack.get_config(name)
         except automation.CommandError:
             self.set_config(name, value, secret=secret)
+
+        if existing_value != value:
+            msg = (
+                f"Unchangeable configuration variable '{name}' not consistent, "
+                f"your configuration: '{value}', Pulumi workspace: '{existing_value}'."
+            )
+            raise DataSafeHavenPulumiError(msg)
 
     def evaluate(self, result: str) -> None:
         """Evaluate a Pulumi operation."""

--- a/tests/infrastructure/test_project_manager.py
+++ b/tests/infrastructure/test_project_manager.py
@@ -49,6 +49,22 @@ class TestSREProjectManager:
         )
         assert "Purged Azure Key Vault shmacmedsresandbosecrets." in stdout
 
+    def test_ensure_config(self, sre_project_manager):
+        sre_project_manager.ensure_config(
+            "azure-native:location", "uksouth", secret=False
+        )
+        sre_project_manager.ensure_config("data-safe-haven:variable", "8", secret=False)
+
+    def test_ensure_config_exception(self, sre_project_manager):
+
+        with raises(
+            DataSafeHavenPulumiError,
+            match=r"Unchangeable configuration option 'azure-native:location'.*your configuration: 'ukwest', Pulumi workspace: 'uksouth'",
+        ):
+            sre_project_manager.ensure_config(
+                "azure-native:location", "ukwest", secret=False
+            )
+
     def test_new_project(
         self,
         context_no_secrets,


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

#2241 

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Protects against changing values which we have declared shouldn't be updated in the Pulumi workspace.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

closes #2199 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

```console
❯ hatch run dsh sre deploy hojo
You are logged into the Azure CLI as:
        user: Jim Madge (…)
        tenant: turing.ac.uk (…)
Are these details correct? [y/n] (y): y
You are logged into the Microsoft Graph API as:
        user: aad.admin.jim.madge@green.develop.turingsafehaven.ac.uk
(…)
        tenant: green.develop.turingsafehaven.ac.uk (…)
Are these details correct? [y/n] (y): y
SRE will be deployed to subscription 'Data Safe Haven Development 2'
('…')
SRE will be registered in SHM 'daimyo.develop.turingsafehaven.ac.uk'
SHM subscription '…'
Loaded stack shm-daimyo-sre-hojo.
Unchangeable configuration variable 'azure-native:subscriptionId' not consistent, your configuration: '…', Pulumi workspace: '…'.
Applying Pulumi configuration options failed..
Pulumi deployment failed.
Could not deploy Secure Research Environment 'hojo'.
```