### PR TITLE
Use SHM name instead of description for Entra app

### DIFF
--- a/data_safe_haven/config/context.py
+++ b/data_safe_haven/config/context.py
@@ -35,7 +35,7 @@ class Context(ContextBase, BaseModel, validate_assignment=True):
 
     @property
     def entra_application_name(self) -> str:
-        return f"Data Safe Haven ({self.description}) Pulumi Service Principal"
+        return f"Data Safe Haven ({self.name}) Pulumi Service Principal"
 
     @property
     def entra_application_secret(self) -> str:

--- a/tests/commands/test_sre.py
+++ b/tests/commands/test_sre.py
@@ -43,7 +43,7 @@ class TestDeploySRE:
         result = runner.invoke(sre_command_group, ["deploy", "sandbox"])
         assert result.exit_code == 1
         assert (
-            "No Entra application 'Data Safe Haven (Acme Deployment) Pulumi Service Principal' was found."
+            "No Entra application 'Data Safe Haven (acmedeployment) Pulumi Service Principal' was found."
             in caplog.text
         )
         assert "Please redeploy your SHM." in caplog.text

--- a/tests/config/test_context_manager.py
+++ b/tests/config/test_context_manager.py
@@ -34,7 +34,7 @@ class TestContext:
     def test_entra_application_name(self, context: Context) -> None:
         assert (
             context.entra_application_name
-            == "Data Safe Haven (Acme Deployment) Pulumi Service Principal"
+            == "Data Safe Haven (acmedeployment) Pulumi Service Principal"
         )
 
     def test_entra_application_secret(self, context: Context, mocker) -> None:


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Uses the SHM/context name as part of the name of the Entra application, instead of the description. 

This ensures the application will have a consistent name.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2242

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested locally