### PR TITLE
Improve DNS delegation feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ expanded.yaml
 
 # ruff cache
 .ruff_cache
+
+**/venv

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -1035,7 +1035,7 @@ class GraphApi:
                 # Check whether all expected nameservers are active
                 with suppress(resolver.NXDOMAIN):
                     self.logger.debug(
-                        f"Checking [green]{domain_name}[/] domain registration status ..."
+                        f"Checking [green]{domain_name}[/] DNS delegation."
                     )
                     active_nameservers = [
                         str(ns) for ns in iter(resolver.resolve(domain_name, "NS"))
@@ -1045,23 +1045,28 @@ class GraphApi:
                         for nameserver in expected_nameservers
                     ):
                         self.logger.info(
-                            f"Verified that [green]{domain_name}[/] is registered as a custom Entra ID domain."
+                            f"[green]{domain_name}[/] DNS has been delegated correctly."
                         )
                         break
                 self.logger.warning(
-                    f"Domain [green]{domain_name}[/] is not currently registered as a custom Entra ID domain."
+                    f"[green]{domain_name}[/] DNS is not delegated correctly."
                 )
                 # Prompt user to set domain delegation manually
-                docs_link = "https://learn.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns#delegate-the-domain"
                 self.logger.info(
-                    f"To proceed you will need to delegate [green]{domain_name}[/] to Azure ({docs_link})"
+                    f"To proceed you will need to delegate [green]{domain_name}[/] to specific Azure nameservers"
                 )
                 ns_list = ", ".join([f"[green]{n}[/]" for n in expected_nameservers])
                 self.logger.info(
-                    f"You will need to create NS records pointing to: {ns_list}"
+                    f"Create {len(ns_list)} [green]NS[/] records for [green]{domain_name}[/] with values: {ns_list}"
+                )
+                docs_link = (
+                    "https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/"
+                )
+                self.logger.info(
+                    f"You can learn more about NS records here: {docs_link}"
                 )
                 if not console.confirm(
-                    f"Are you ready to check whether [green]{domain_name}[/] has been delegated to Azure?",
+                    f"Are you ready to check whether [green]{domain_name}[/] has been delegated to the correct Azure nameservers?",
                     default_to_yes=True,
                 ):
                     self.logger.error("User terminated check for domain delegation.")

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -1056,8 +1056,13 @@ class GraphApi:
                     f"To proceed you will need to delegate [green]{domain_name}[/] to specific Azure nameservers"
                 )
                 ns_list = ", ".join([f"[green]{n}[/]" for n in expected_nameservers])
+                domain_parent = ".".join(domain_name.split(".")[1:])
                 self.logger.info(
-                    f"Create {len(ns_list)} [green]NS[/] records for [green]{domain_name}[/] with values: {ns_list}"
+                    f"Create {len(ns_list)} [green]NS[/] records for [green]{domain_name}[/] (for example in the zone of {domain_parent})"
+                )
+                console.tabulate(
+                    header=["domain", "record type", "value"],
+                    rows=[[domain_name, "NS", ns_item] for ns_item in ns_list],
                 )
                 docs_link = (
                     "https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/"

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -1061,7 +1061,10 @@ class GraphApi:
                 )
                 console.tabulate(
                     header=["domain", "record type", "value"],
-                    rows=[[domain_name, "NS", nameserver] for nameserver in expected_nameservers],
+                    rows=[
+                        [domain_name, "NS", nameserver]
+                        for nameserver in expected_nameservers
+                    ],
                 )
                 docs_link = (
                     "https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/"

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -1055,14 +1055,13 @@ class GraphApi:
                 self.logger.info(
                     f"To proceed you will need to delegate [green]{domain_name}[/] to specific Azure nameservers"
                 )
-                ns_list = ", ".join([f"[green]{n}[/]" for n in expected_nameservers])
                 domain_parent = ".".join(domain_name.split(".")[1:])
                 self.logger.info(
-                    f"Create {len(ns_list)} [green]NS[/] records for [green]{domain_name}[/] (for example in the zone of {domain_parent})"
+                    f"Create {len(expected_nameservers)} [green]NS[/] records for [green]{domain_name}[/] (for example in the zone of {domain_parent})"
                 )
                 console.tabulate(
                     header=["domain", "record type", "value"],
-                    rows=[[domain_name, "NS", ns_item] for ns_item in ns_list],
+                    rows=[[domain_name, "NS", nameserver] for nameserver in expected_nameservers],
                 )
                 docs_link = (
                     "https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/"


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2228

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested locally


```console
Ensured that DNS TXT record @ exists in zone daimyo.develop.turingsafehaven.ac.uk.
daimyo.develop.turingsafehaven.ac.uk DNS is not delegated correctly.
To proceed you will need to delegate daimyo.develop.turingsafehaven.ac.uk to specific
Azure nameservers
Create 4 NS records for daimyo.develop.turingsafehaven.ac.uk (for example in the zone of
develop.turingsafehaven.ac.uk)
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ domain                               ┃ record type ┃ value                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
│ daimyo.develop.turingsafehaven.ac.uk │ NS          │ ns1-36.azure-dns.com.  │
│ daimyo.develop.turingsafehaven.ac.uk │ NS          │ ns2-36.azure-dns.net.  │
│ daimyo.develop.turingsafehaven.ac.uk │ NS          │ ns3-36.azure-dns.org.  │
│ daimyo.develop.turingsafehaven.ac.uk │ NS          │ ns4-36.azure-dns.info. │
└──────────────────────────────────────┴─────────────┴────────────────────────┘
You can learn more about NS records here:
https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/
Are you ready to check whether daimyo.develop.turingsafehaven.ac.uk has been delegated to
the correct Azure nameservers? [y/n] (y):
```