### PR TITLE
[WIP] Change logic for generating/loading stack to avoid mismatching key errors

### DIFF
--- a/data_safe_haven/commands/sre.py
+++ b/data_safe_haven/commands/sre.py
@@ -50,6 +50,7 @@ def deploy(
         pulumi_config = DSHPulumiConfig.from_remote_or_create(
             context, encrypted_key=None, projects={}
         )
+
         sre_config = SREConfig.from_remote_by_name(context, name)
 
         # Check whether current IP address is authorised to take administrator actions
@@ -68,6 +69,7 @@ def deploy(
             pulumi_config=pulumi_config,
             create_project=True,
         )
+
         # Set Azure options
         stack.add_option(
             "azure-native:location", sre_config.azure.location, replace=False

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -119,27 +119,46 @@ class ProjectManager:
         """Load the Pulumi stack, creating if needed."""
         if not self._stack:
             self.logger.debug(f"Creating/loading stack [green]{self.stack_name}[/].")
+            # Note: `create_or_select_stack` is not used here because
+            # when creating a stack, it generates a new encryption key rather than using the project's key
+            # There is no way to check if a stack exists other than trying to select it
+            #
             try:
-                self._stack = automation.create_or_select_stack(
+                self._stack = automation.select_stack(
                     opts=automation.LocalWorkspaceOptions(
                         env_vars=self.account.env,
                         project_settings=self.project_settings,
-                        secrets_provider=self.context.pulumi_secrets_provider_url,
                         stack_settings={self.stack_name: self.stack_settings},
+                        secrets_provider=self.context.pulumi_secrets_provider_url,
                     ),
                     program=self.program,
                     project_name=self.project_name,
                     stack_name=self.stack_name,
                 )
-                self.logger.info(f"Loaded stack [green]{self.stack_name}[/].")
-                # Ensure encrypted key is stored in the Pulumi configuration
-                self.update_dsh_pulumi_encrypted_key(self._stack.workspace)
-                # Ensure workspace plugins are installed
-                self.install_plugins(self._stack.workspace)
-            except automation.CommandError as exc:
-                self.log_exception(exc)
-                msg = f"Could not load Pulumi stack {self.stack_name}."
-                raise DataSafeHavenPulumiError(msg) from exc
+            except automation.CommandError:
+                try:
+                    self._stack = automation.create_stack(
+                        opts=automation.LocalWorkspaceOptions(
+                            env_vars=self.account.env,
+                            project_settings=self.project_settings,
+                            secrets_provider=self.context.pulumi_secrets_provider_url,
+                        ),
+                        program=self.program,
+                        project_name=self.project_name,
+                        stack_name=self.stack_name,
+                    )
+                    self._stack.workspace.save_stack_settings(
+                        self.stack_name, self.stack_settings
+                    )
+                except automation.CommandError as exc:
+                    self.log_exception(exc)
+                    msg = f"Could not create Pulumi stack {self.stack_name}."
+                    raise DataSafeHavenPulumiError(msg) from exc
+            self.logger.info(f"Loaded stack [green]{self.stack_name}[/].")
+            # Ensure encrypted key is stored in the Pulumi configuration
+            self.update_dsh_pulumi_encrypted_key(self._stack.workspace)
+            # Ensure workspace plugins are installed
+            self.install_plugins(self._stack.workspace)
         return self._stack
 
     def add_option(self, name: str, value: str, *, replace: bool) -> None:
@@ -428,7 +447,6 @@ class ProjectManager:
     def update_dsh_pulumi_encrypted_key(self, workspace: automation.Workspace) -> None:
         """Update encrypted key in the DSHPulumiProject object"""
         stack_key = workspace.stack_settings(stack_name=self.stack_name).encrypted_key
-
         if not self.pulumi_config.encrypted_key:
             self.pulumi_config.encrypted_key = stack_key
         elif self.pulumi_config.encrypted_key != stack_key:

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -119,10 +119,11 @@ class ProjectManager:
         """Load the Pulumi stack, creating if needed."""
         if not self._stack:
             self.logger.debug(f"Creating/loading stack [green]{self.stack_name}[/].")
-            # Note: `create_or_select_stack` is not used here because
-            # when creating a stack, it generates a new encryption key rather than using the project's key
-            # There is no way to check if a stack exists other than trying to select it
-            #
+            # Note: `create_or_select_stack` is not used here because we need to know whether the stack exists or not.
+            # There is no way to check if a stack exists other than trying to `create_stack` or `select_stack` and catching the error.
+            # `create_or_select_stack` never generates an error, and doesn't tell us whether the stack was created or selected.
+            # When creating a stack, it generates a new encryption key rather than using the project's key, so we need to set the key
+            # manually after creating the stack.
             try:
                 self._stack = automation.select_stack(
                     opts=automation.LocalWorkspaceOptions(
@@ -155,8 +156,6 @@ class ProjectManager:
                     msg = f"Could not create Pulumi stack {self.stack_name}."
                     raise DataSafeHavenPulumiError(msg) from exc
             self.logger.info(f"Loaded stack [green]{self.stack_name}[/].")
-            # Ensure encrypted key is stored in the Pulumi configuration
-            self.update_dsh_pulumi_encrypted_key(self._stack.workspace)
             # Ensure workspace plugins are installed
             self.install_plugins(self._stack.workspace)
         return self._stack
@@ -443,15 +442,6 @@ class ProjectManager:
             key: item.value for key, item in self.stack.get_all_config().items()
         }
         self.pulumi_project.stack_config = all_config_dict
-
-    def update_dsh_pulumi_encrypted_key(self, workspace: automation.Workspace) -> None:
-        """Update encrypted key in the DSHPulumiProject object"""
-        stack_key = workspace.stack_settings(stack_name=self.stack_name).encrypted_key
-        if not self.pulumi_config.encrypted_key:
-            self.pulumi_config.encrypted_key = stack_key
-        elif self.pulumi_config.encrypted_key != stack_key:
-            msg = "Stack encrypted key does not match project encrypted key"
-            raise DataSafeHavenPulumiError(msg)
 
 
 class SREProjectManager(ProjectManager):


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

When a new stack is created (e.g. during the first run of `dsh sre deploy x`), a new encrypted key is generated when trying to load the stack and stored in the local workspace used for this run of the function. This doesn't match the project encrypted key.

When an existing stack is selected (such as on a second run of `dsh sre deploy x`), the project key is used correctly.

The `create_or_select_stack` function doesn't tell you whether a stack was created or selected. This PR splits `select_stack` and `create_stack` separately, catching errors from the stack not existing or already existing respectively. If the stack is being created, then manually overwrite the newly generated key with the existing project key.

An alternative would be to keep the existing `create_or_select_stack` function and always overwrite the generated key with the project key

Either way, the separate step of checking if the keys match is no longer required, as the keys will always match.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2249 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested locally
