### PR TITLE
[Documentation] Changing suggested SKU to Standard_D8s_v5

### DIFF
--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -167,7 +167,7 @@ As some general recommendations,
 
 - For general purpose use, the D family gives decent performance and a good balance of CPU and memory.
   The [Dsv6 series](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv6-series#sizes-in-series) is a good starting point and can be scaled from 2 CPUs and 8 GB RAM to 128 CPUs and 512 GB RAM.
-    - `Standard_D8s_v6` should give reasonable performance for a single concurrent user.
+    - `Standard_D8s_v5` should give reasonable performance for a single concurrent user.
 - For GPU accelerated work, the NC family provides Nvidia GPUs and a good balance of CPU and memory.
   In order of increasing throughput, the `NCv3` series features Nvidia V100 GPUs, the `NC_A100_v4` series features Nvidia A100 GPUs, and the `NCads_H100_v5` series features Nvidia H100 GPUs.
     - `Stanard_NC6s_v3` should give reasonable performance for a single concurrent user with AI/ML workloads.


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

At the moment, the documentation suggests using a `Standard_D8s_v6` for a single concurrent user. However, the [Dsv6 sizes are in preview](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv6-series?tabs=sizebasic) and not generally available.

In this PR, we change that suggestion to `Standard_D8s_v5`.


### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2271

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

`az vm list-sizes --location "uksouth"` includes `Standard_D8s_v5` at the time of writing.
