### PR TITLE
Retrieve SRE sub name and use that when connecting to guac database

### DIFF
--- a/data_safe_haven/administration/users/guacamole_users.py
+++ b/data_safe_haven/administration/users/guacamole_users.py
@@ -23,7 +23,10 @@ class GuacamoleUsers:
             pulumi_config=pulumi_config,
         )
         # Read the SRE database secret from key vault
-        azure_sdk = AzureSdk(context.subscription_name)
+        azure_sdk = AzureSdk(subscription_name=context.subscription_name)
+        sre_subscription_name = azure_sdk.get_subscription_name(
+            config.azure.subscription_id
+        )
         connection_db_server_password = azure_sdk.get_keyvault_secret(
             sre_stack.output("data")["key_vault_name"],
             sre_stack.output("data")["password_user_database_admin_secret"],
@@ -33,7 +36,7 @@ class GuacamoleUsers:
             connection_db_server_password,
             sre_stack.output("remote_desktop")["connection_db_server_name"],
             sre_stack.output("remote_desktop")["resource_group_name"],
-            context.subscription_name,
+            sre_subscription_name,
         )
         self.users_: Sequence[ResearchUser] | None = None
         self.postgres_script_path: pathlib.Path = (


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

When retrieving users from the Guacamole user database, the context/SHM subscription name was being used. This causes problems when the SRE is on a different subscription to the SHM. This PR ensures the SRE subscription name is used.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2349 

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested on a sandbox deployed to a different sub than its SHM
