### PR TITLE
Better teardown logging

### DIFF
--- a/data_safe_haven/external/api/azure_sdk.py
+++ b/data_safe_haven/external/api/azure_sdk.py
@@ -1023,7 +1023,7 @@ class AzureSdk:
                     location=location,
                 )
             except HttpResponseError:
-                self.logger.info(
+                self.logger.debug(
                     f"Key Vault [green]{key_vault_name}[/] does not need to be purged."
                 )
                 return False
@@ -1050,7 +1050,7 @@ class AzureSdk:
                 ):
                     msg = f"Key Vault '{key_vault_name}' exists in deleted state."
                     raise AzureError(msg)
-            self.logger.info(f"Purged Key Vault [green]{key_vault_name}[/].")
+            self.logger.debug(f"Purged Key Vault [green]{key_vault_name}[/].")
             return True
         except AzureError as exc:
             msg = f"Failed to remove Key Vault '{key_vault_name}'."
@@ -1118,7 +1118,7 @@ class AzureSdk:
             )
             # Remove the requested blob
             blob_client.delete_blob(delete_snapshots="include")
-            self.logger.info(
+            self.logger.debug(
                 f"Removed file [green]{blob_name}[/] from blob storage.",
             )
         except (AzureError, DataSafeHavenAzureStorageError) as exc:

--- a/tests/external/api/test_azure_sdk.py
+++ b/tests/external/api/test_azure_sdk.py
@@ -389,11 +389,11 @@ class TestAzureSdk:
         capsys,
     ):
         sdk = AzureSdk("subscription name")
-        sdk.purge_keyvault("key_vault_name", "location")
+        result = sdk.purge_keyvault("key_vault_name", "location")
         stdout, _ = capsys.readouterr()
         assert "Found deleted key vault key_vault_name in location" in stdout
         assert "Purging deleted key vault key_vault_name in location" in stdout
-        assert "Purged Key Vault key_vault_name" in stdout
+        assert result is True
 
     @pytest.mark.parametrize(
         "storage_account_name,exists",


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Previously `dsh sre teardown` produced output like:

```
Pulumi operation succeeded.
Removed Pulumi stack shm-blue-sre-indigo.
Removed file .pulumi/stacks/data-safe-haven/shm-blue-sre-indigo.json.bak from blob storage.
Removed Pulumi stack backup shm-blue-sre-indigo.json.bak.
Purged Key Vault shmbluesreindigosecrets.
Purged Azure Key Vault shmbluesreindigosecrets.
```

with this change it will produce

```
Pulumi operation succeeded.
Removed Pulumi stack shm-blue-sre-indigo.
Removed Pulumi stack backup shm-blue-sre-indigo.json.bak.
Purged Azure Key Vault shmbluesreindigosecrets.
```

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
