### PR TITLE
Mounting a volume to fix Gitea after container restart.

### DIFF
--- a/data_safe_haven/infrastructure/programs/sre/gitea_server.py
+++ b/data_safe_haven/infrastructure/programs/sre/gitea_server.py
@@ -90,6 +90,18 @@ class SREGiteaServerComponent(ComponentResource):
             signed_identifiers=[],
             opts=child_opts,
         )
+
+        file_share_gitea = storage.FileShare(
+            f"{self._name}_file_share_gitea_data",
+            access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
+            account_name=props.storage_account_name,
+            resource_group_name=props.resource_group_name,
+            share_name="gitea-data",
+            share_quota=2,
+            signed_identifiers=[],
+            opts=child_opts,
+        )
+
         file_share_gitea_gitea = storage.FileShare(
             f"{self._name}_file_share_gitea_gitea",
             access_tier=storage.ShareAccessTier.TRANSACTION_OPTIMIZED,
@@ -272,6 +284,11 @@ class SREGiteaServerComponent(ComponentResource):
                             name="gitea-app-custom",
                             read_only=True,
                         ),
+                        containerinstance.VolumeMountArgs(
+                            mount_path="/data",
+                            name="gitea-gitea-data",
+                            read_only=False,
+                        ),
                     ],
                 ),
             ],
@@ -319,6 +336,14 @@ class SREGiteaServerComponent(ComponentResource):
                         storage_account_name=props.storage_account_name,
                     ),
                     name="caddy-etc-caddy",
+                ),
+                containerinstance.VolumeArgs(
+                    azure_file=containerinstance.AzureFileVolumeArgs(
+                        share_name=file_share_gitea.name,
+                        storage_account_key=props.storage_account_key,
+                        storage_account_name=props.storage_account_name,
+                    ),
+                    name="gitea-gitea-data",
                 ),
                 containerinstance.VolumeArgs(
                     azure_file=containerinstance.AzureFileVolumeArgs(


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [ ] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [ ] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [ ] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->
N/A

### :arrow_heading_up: Summary

When installing Gitea using containers, the [`/data` directory needs to be mounted as a volume](https://docs.gitea.com/installation/install-with-docker). The absence of this volume in `dsh==5.4.0` was causing Gitea to become unusable after a container restart (see: https://github.com/alan-turing-institute/data-safe-haven/issues/2422 ).

This PR addresses that issue, by mounting an Azure File Share.

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

Closes https://github.com/alan-turing-institute/data-safe-haven/issues/2422

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

The following manual test was performed:

1.  Deployed a new SRE using the version available in `develop`.
2. Connect to Gitea, create a repository, and push a commit. Myself (as well as @craddm ) verified that https://github.com/alan-turing-institute/data-safe-haven/issues/2422 replicates, when trying to connect to Gitea again.
3. Teardown the SRE and deploy the version available in the current branch.
4. After restarting the Gitea container, is still possible to access Gitea via web and push changes to the original repo.


