### PR TITLE
Enabling SRE users to write into /mnt/scratch

### DIFF
--- a/data_safe_haven/resources/workspace/ansible/desired_state.yaml
+++ b/data_safe_haven/resources/workspace/ansible/desired_state.yaml
@@ -46,6 +46,10 @@
       ansible.builtin.import_tasks: tasks/package_proxy.yaml
       tags: package_proxies
 
+    - name: Configure scratchpad
+      ansible.builtin.import_tasks: tasks/scratchpad.yaml
+      tags: scratchpad
+
     - name: Provision smoke tests
       ansible.builtin.import_tasks: tasks/smoke_tests.yaml
       tags: smoke_tests

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -1,12 +1,10 @@
 ---
-- name: Collect hardware information
-  ansible.builtin.setup:
-    gather_subset:
-      - hardware
-
-- name: Store temporary disks in list
-  ansible.builtin.set_fact:
-    temporary_disks: "{{ hostvars[inventory_hostname].ansible_devices.keys() | map('regex_search', 'sdb.*') | select('string') | list }}"
+- name: Find temporary disk on Azure VM
+  ansible.builtin.shell: |
+    find /dev/disk/azure -name 'resource-part[0123456789]' | sort | sed -n 1p | xargs readlink -f
+  register: search_result
+  changed_when: false
+  ignore_errors: true
 
 - name: Enable user writing on scratchpad.
   ansible.builtin.file:
@@ -15,4 +13,4 @@
     owner: root
     group: root
     mode: "0777"
-  when: "temporary_disks is defined and (temporary_disks|length>0)"
+  when: "search_result.stdout != ''"

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -6,4 +6,4 @@
     state: directory
     owner: root
     group: root
-    mode: 0777
+    mode: '0777'

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -1,0 +1,9 @@
+---
+
+- name: Enable user writing on scratchpad (cgc6).
+  ansible.builtin.file:
+    path: /mnt/scratch
+    state: directory
+    owner: root
+    group: root
+    mode: 0777

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -1,6 +1,6 @@
 ---
 
-- name: Enable user writing on scratchpad (cgc6).
+- name: Enable user writing on scratchpad.
   ansible.builtin.file:
     path: /mnt/scratch
     state: directory

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Collect hardware information
+  ansible.builtin.setup:
+    gather_subset:
+      - hardware
+
+- name: Store temporary disks in list
+  ansible.builtin.set_fact:
+    temporary_disks: "{{ hostvars[inventory_hostname].ansible_devices.keys() | map('regex_search', 'sdb.*') | select('string') | list }}"
 
 - name: Enable user writing on scratchpad.
   ansible.builtin.file:
@@ -6,4 +14,5 @@
     state: directory
     owner: root
     group: root
-    mode: '0777'
+    mode: "0777"
+  when: "temporary_disks is defined and (temporary_disks|length>0)"

--- a/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/scratchpad.yaml
@@ -1,16 +1,14 @@
 ---
 - name: Find temporary disk on Azure VM
-  ansible.builtin.shell: |
-    find /dev/disk/azure -name 'resource-part[0123456789]' | sort | sed -n 1p | xargs readlink -f
-  register: search_result
-  changed_when: false
-  ignore_errors: true
+  ansible.builtin.stat:
+    path: /dev/disk/azure/resource-part1
+  register: ephemeral_disk_link
 
-- name: Enable user writing on scratchpad.
+- name: Set permissions of scratch directory
   ansible.builtin.file:
     path: /mnt/scratch
     state: directory
     owner: root
     group: root
     mode: "0777"
-  when: "search_result.stdout != ''"
+  when: ephemeral_disk_link.stat.exists and ephemeral_disk_link.stat.islnk

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -38,7 +38,7 @@ write_files:
 
 mounts:
   # Mount ephemeral storage at resource instead of default /mnt
-  # - [ephemeral0, /mnt/scratch]
+  - [ephemeral0, /mnt/scratch]
   # Desired state configuration is in a blob container mounted as NFSv3
   - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}/desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]
   # Secure data is in a blob container mounted as NFSv3

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -38,7 +38,7 @@ write_files:
 
 mounts:
   # Mount ephemeral storage at resource instead of default /mnt
-  - [ephemeral0, /mnt/scratch]
+  # - [ephemeral0, /mnt/scratch]
   # Desired state configuration is in a blob container mounted as NFSv3
   - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}/desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]
   # Secure data is in a blob container mounted as NFSv3


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

At the moment, `/mnt/scratch` is only editable by `root`, without a clear purpose (besides the workaround implemented in https://github.com/alan-turing-institute/data-safe-haven/issues/2221 ). However, it would be convenient for it to accessible to SRE users similarly as `/mnt/shared`. While it is ephemeral storage, it has the advantage that read/writes are faster when compared to network storage.

This PR implements that functionality.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes: https://github.com/alan-turing-institute/data-safe-haven/issues/2413

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

I deployed an SRE with the current changes and two SRDs. One of them is a Linux `Standard_D2ds_v5` with a temporary disk. As per [the documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview), it has a temporary disk at `/dev/sdb`:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/d429378a-0ff8-404c-8ae8-264fa529e30a" />

We can see that the permissions of `/mnt/scratch` now allow writes from other users:

<img width="670" alt="image" src="https://github.com/user-attachments/assets/5ae87bbf-5a48-470f-884f-9c1d5d37b0c1" />

In contrast, the `Standard_D2s_v5`  [does not offer local storage](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv5-series?tabs=sizebasic]). In this case, the permissions of `/mnt/scratch` were not altered:

<img width="680" alt="image" src="https://github.com/user-attachments/assets/1371f3ea-cefa-4dda-bf88-341816405a3b" />



