### PR TITLE
Enabling configuring the size of Nexus' persistent directory

### DIFF
--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -56,7 +56,7 @@ class ConfigSubsectionNexus(BaseModel, validate_assignment=True):
 
 
 class ConfigSectionUserServices(BaseModel, validate_assignment=True):
-    nexus: ConfigSubsectionNexus = ConfigSubsectionNexus(persistent_quota_gb=2)
+    nexus: ConfigSubsectionNexus = ConfigSubsectionNexus(persistent_quota_gb=10)
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -46,13 +46,17 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
     allow_paste: bool
 
 
-class ConfigSubsectionServiceQuotaGB(BaseModel, validate_assignment=True):
-    nexus: PositiveInt
-
-
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
     home: AzurePremiumFileShareSize
     shared: AzurePremiumFileShareSize
+
+
+class ConfigSubsectionNexus(BaseModel, validate_assignment=True):
+    persistent_quota_gb: PositiveInt
+
+
+class ConfigSectionUserServices(BaseModel, validate_assignment=True):
+    nexus: ConfigSubsectionNexus | None = ConfigSubsectionNexus(persistent_quota_gb=2)
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):
@@ -65,9 +69,6 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
     data_provider_ip_addresses: list[IpAddress] = []
     remote_desktop: ConfigSubsectionRemoteDesktopOpts
     research_user_ip_addresses: list[IpAddress] | AzureServiceTag = []
-    service_quota_gb: ConfigSubsectionServiceQuotaGB = ConfigSubsectionServiceQuotaGB(
-        nexus=2
-    )
     storage_quota_gb: ConfigSubsectionStorageQuotaGB
     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE
     timezone: TimeZone = "Etc/UTC"

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -56,7 +56,7 @@ class ConfigSubsectionNexus(BaseModel, validate_assignment=True):
 
 
 class ConfigSectionUserServices(BaseModel, validate_assignment=True):
-    nexus: ConfigSubsectionNexus | None = ConfigSubsectionNexus(persistent_quota_gb=2)
+    nexus: ConfigSubsectionNexus = ConfigSubsectionNexus(persistent_quota_gb=2)
 
 
 class ConfigSectionSRE(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ipaddress import ip_network
 from itertools import combinations
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, PositiveInt, field_validator
 
 from data_safe_haven.types import (
     AzureLocation,
@@ -46,6 +46,10 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
     allow_paste: bool
 
 
+class ConfigSubsectionServiceQuotaGB(BaseModel, validate_assignment=True):
+    nexus: PositiveInt
+
+
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
     home: AzurePremiumFileShareSize
     shared: AzurePremiumFileShareSize
@@ -61,6 +65,9 @@ class ConfigSectionSRE(BaseModel, validate_assignment=True):
     data_provider_ip_addresses: list[IpAddress] = []
     remote_desktop: ConfigSubsectionRemoteDesktopOpts
     research_user_ip_addresses: list[IpAddress] | AzureServiceTag = []
+    service_quota_gb: ConfigSubsectionServiceQuotaGB = ConfigSubsectionServiceQuotaGB(
+        nexus=2
+    )
     storage_quota_gb: ConfigSubsectionStorageQuotaGB
     software_packages: SoftwarePackageCategory = SoftwarePackageCategory.NONE
     timezone: TimeZone = "Etc/UTC"

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -12,6 +12,7 @@ from .config_sections import (
     ConfigSectionDockerHub,
     ConfigSectionSRE,
     ConfigSectionUserServices,
+    ConfigSubsectionNexus,
     ConfigSubsectionRemoteDesktopOpts,
     ConfigSubsectionStorageQuotaGB,
 )
@@ -123,5 +124,10 @@ class SREConfig(AzureSerialisableModel):
                 workspace_skus=[
                     "List of Azure VM SKUs that will be used for data analysis."
                 ],
+            ),
+            user_services=ConfigSectionUserServices.model_construct(
+                nexus=ConfigSubsectionNexus.model_construct(
+                    persistent_quota_gb="Total size in GiB for Nexus' persistent directory. "
+                )
             ),
         )

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -11,6 +11,7 @@ from .config_sections import (
     ConfigSectionAzure,
     ConfigSectionDockerHub,
     ConfigSectionSRE,
+    ConfigSectionUserServices,
     ConfigSubsectionRemoteDesktopOpts,
     ConfigSubsectionStorageQuotaGB,
 )
@@ -32,6 +33,7 @@ class SREConfig(AzureSerialisableModel):
     dockerhub: ConfigSectionDockerHub
     name: SafeSreName
     sre: ConfigSectionSRE
+    user_services: ConfigSectionUserServices | None = ConfigSectionUserServices()
 
     @property
     def filename(self) -> str:

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -34,7 +34,7 @@ class SREConfig(AzureSerialisableModel):
     dockerhub: ConfigSectionDockerHub
     name: SafeSreName
     sre: ConfigSectionSRE
-    user_services: ConfigSectionUserServices | None = ConfigSectionUserServices()
+    user_services: ConfigSectionUserServices = ConfigSectionUserServices()
 
     @property
     def filename(self) -> str:
@@ -127,7 +127,7 @@ class SREConfig(AzureSerialisableModel):
             ),
             user_services=ConfigSectionUserServices.model_construct(
                 nexus=ConfigSubsectionNexus.model_construct(
-                    persistent_quota_gb="Total size in GiB for Nexus' persistent directory. "
+                    persistent_quota_gb="Total size in GiB for Nexus' persistent directory. "  # type: ignore
                 )
             ),
         )

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -352,7 +352,7 @@ class DeclarativeSRE:
                 resource_group_name=resource_group.name,
                 software_packages=self.config.sre.software_packages,
                 sre_fqdn=networking.sre_fqdn,
-                service_quota_gb_nexus=self.config.sre.service_quota_gb.nexus,
+                nexus_persistent_quota_gb=self.config.user_services.nexus.persistent_quota_gb,
                 storage_account_key=data.storage_account_data_configuration_key,
                 storage_account_name=data.storage_account_data_configuration_name,
                 subnet_containers=networking.subnet_user_services_containers,

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -352,6 +352,7 @@ class DeclarativeSRE:
                 resource_group_name=resource_group.name,
                 software_packages=self.config.sre.software_packages,
                 sre_fqdn=networking.sre_fqdn,
+                service_quota_gb_nexus=self.config.sre.service_quota_gb.nexus,
                 storage_account_key=data.storage_account_data_configuration_key,
                 storage_account_name=data.storage_account_data_configuration_name,
                 subnet_containers=networking.subnet_user_services_containers,

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -34,6 +34,7 @@ class SRESoftwareRepositoriesProps:
         resource_group_name: Input[str],
         software_packages: SoftwarePackageCategory,
         sre_fqdn: Input[str],
+        service_quota_gb_nexus: Input[int],
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_id: Input[str],
@@ -49,6 +50,7 @@ class SRESoftwareRepositoriesProps:
             SoftwarePackageCategory.NONE: None,
         }[software_packages]
         self.resource_group_name = resource_group_name
+        self.service_quota_gb_nexus = service_quota_gb_nexus
         self.sre_fqdn = sre_fqdn
         self.storage_account_key = storage_account_key
         self.storage_account_name = storage_account_name
@@ -90,7 +92,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus",
-            share_quota=2,
+            share_quota=props.service_quota_gb_nexus,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -34,7 +34,7 @@ class SRESoftwareRepositoriesProps:
         resource_group_name: Input[str],
         software_packages: SoftwarePackageCategory,
         sre_fqdn: Input[str],
-        service_quota_gb_nexus: Input[int],
+        persistent_quota_gb_nexus: Input[int],
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_id: Input[str],
@@ -50,7 +50,7 @@ class SRESoftwareRepositoriesProps:
             SoftwarePackageCategory.NONE: None,
         }[software_packages]
         self.resource_group_name = resource_group_name
-        self.service_quota_gb_nexus = service_quota_gb_nexus
+        self.persistent_quota_gb_nexus = persistent_quota_gb_nexus
         self.sre_fqdn = sre_fqdn
         self.storage_account_key = storage_account_key
         self.storage_account_name = storage_account_name
@@ -92,7 +92,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus",
-            share_quota=props.service_quota_gb_nexus,
+            share_quota=props.persistent_quota_gb_nexus,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -34,7 +34,7 @@ class SRESoftwareRepositoriesProps:
         resource_group_name: Input[str],
         software_packages: SoftwarePackageCategory,
         sre_fqdn: Input[str],
-        persistent_quota_gb_nexus: Input[int],
+        nexus_persistent_quota_gb: Input[int],
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_id: Input[str],
@@ -50,7 +50,7 @@ class SRESoftwareRepositoriesProps:
             SoftwarePackageCategory.NONE: None,
         }[software_packages]
         self.resource_group_name = resource_group_name
-        self.persistent_quota_gb_nexus = persistent_quota_gb_nexus
+        self.nexus_persistent_quota_gb = nexus_persistent_quota_gb
         self.sre_fqdn = sre_fqdn
         self.storage_account_key = storage_account_key
         self.storage_account_name = storage_account_name
@@ -92,7 +92,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
             account_name=props.storage_account_name,
             resource_group_name=props.resource_group_name,
             share_name="software-repositories-nexus",
-            share_quota=props.persistent_quota_gb_nexus,
+            share_quota=props.nexus_persistent_quota_gb,
             signed_identifiers=[],
             opts=child_opts,
         )

--- a/data_safe_haven/infrastructure/programs/sre/user_services.py
+++ b/data_safe_haven/infrastructure/programs/sre/user_services.py
@@ -41,6 +41,7 @@ class SREUserServicesProps:
         resource_group_name: Input[str],
         software_packages: SoftwarePackageCategory,
         sre_fqdn: Input[str],
+        service_quota_gb_nexus: Input[int],
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_containers: Input[network.GetSubnetResult],
@@ -63,6 +64,7 @@ class SREUserServicesProps:
         self.log_analytics_workspace = log_analytics_workspace
         self.nexus_admin_password = Output.secret(nexus_admin_password)
         self.resource_group_name = resource_group_name
+        self.service_quota_gb_nexus = service_quota_gb_nexus
         self.software_packages = software_packages
         self.sre_fqdn = sre_fqdn
         self.storage_account_key = storage_account_key
@@ -161,6 +163,7 @@ class SREUserServicesComponent(ComponentResource):
                 resource_group_name=props.resource_group_name,
                 sre_fqdn=props.sre_fqdn,
                 software_packages=props.software_packages,
+                service_quota_gb_nexus=props.service_quota_gb_nexus,
                 storage_account_key=props.storage_account_key,
                 storage_account_name=props.storage_account_name,
                 subnet_id=props.subnet_software_repositories_id,

--- a/data_safe_haven/infrastructure/programs/sre/user_services.py
+++ b/data_safe_haven/infrastructure/programs/sre/user_services.py
@@ -163,7 +163,7 @@ class SREUserServicesComponent(ComponentResource):
                 resource_group_name=props.resource_group_name,
                 sre_fqdn=props.sre_fqdn,
                 software_packages=props.software_packages,
-                persistent_quota_gb_nexus=props.nexus_persistent_quota_gb,
+                nexus_persistent_quota_gb=props.nexus_persistent_quota_gb,
                 storage_account_key=props.storage_account_key,
                 storage_account_name=props.storage_account_name,
                 subnet_id=props.subnet_software_repositories_id,

--- a/data_safe_haven/infrastructure/programs/sre/user_services.py
+++ b/data_safe_haven/infrastructure/programs/sre/user_services.py
@@ -41,7 +41,7 @@ class SREUserServicesProps:
         resource_group_name: Input[str],
         software_packages: SoftwarePackageCategory,
         sre_fqdn: Input[str],
-        service_quota_gb_nexus: Input[int],
+        nexus_persistent_quota_gb: Input[int],
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_containers: Input[network.GetSubnetResult],
@@ -64,7 +64,7 @@ class SREUserServicesProps:
         self.log_analytics_workspace = log_analytics_workspace
         self.nexus_admin_password = Output.secret(nexus_admin_password)
         self.resource_group_name = resource_group_name
-        self.service_quota_gb_nexus = service_quota_gb_nexus
+        self.nexus_persistent_quota_gb = nexus_persistent_quota_gb
         self.software_packages = software_packages
         self.sre_fqdn = sre_fqdn
         self.storage_account_key = storage_account_key
@@ -163,7 +163,7 @@ class SREUserServicesComponent(ComponentResource):
                 resource_group_name=props.resource_group_name,
                 sre_fqdn=props.sre_fqdn,
                 software_packages=props.software_packages,
-                service_quota_gb_nexus=props.service_quota_gb_nexus,
+                persistent_quota_gb_nexus=props.nexus_persistent_quota_gb,
                 storage_account_key=props.storage_account_key,
                 storage_account_name=props.storage_account_name,
                 subnet_id=props.subnet_software_repositories_id,

--- a/tests/config/test_config_sections.py
+++ b/tests/config/test_config_sections.py
@@ -4,10 +4,10 @@ from pydantic import ValidationError
 from data_safe_haven.config.config_sections import (
     ConfigSectionAzure,
     ConfigSectionDockerHub,
-    ConfigSubsectionNexus,
     ConfigSectionSHM,
     ConfigSectionSRE,
     ConfigSectionUserServices,
+    ConfigSubsectionNexus,
     ConfigSubsectionRemoteDesktopOpts,
     ConfigSubsectionStorageQuotaGB,
 )

--- a/tests/config/test_config_sections.py
+++ b/tests/config/test_config_sections.py
@@ -118,17 +118,19 @@ class TestConfigSectionSHM:
 
 class TestConfigSectionUserServices:
     def test_constructor(self):
+        user_provided_quota: int = 20
         user_services_config = ConfigSectionUserServices(
-            nexus=ConfigSubsectionNexus(persistent_quota_gb=10)
+            nexus=ConfigSubsectionNexus(persistent_quota_gb=user_provided_quota)
         )
 
         assert user_services_config.nexus is not None
-        assert user_services_config.nexus.persistent_quota_gb == 10
+        assert user_services_config.nexus.persistent_quota_gb == user_provided_quota
 
     def test_constructor_defaults(self):
+        default_quota_size: int = 10
         user_services_config = ConfigSectionUserServices()
         assert user_services_config.nexus is not None
-        assert user_services_config.nexus.persistent_quota_gb == 2
+        assert user_services_config.nexus.persistent_quota_gb == default_quota_size
 
     def test_invalid_nexus_quota(self):
         with pytest.raises(ValueError, match="Input should be greater than 0"):

--- a/tests/config/test_config_sections.py
+++ b/tests/config/test_config_sections.py
@@ -4,8 +4,10 @@ from pydantic import ValidationError
 from data_safe_haven.config.config_sections import (
     ConfigSectionAzure,
     ConfigSectionDockerHub,
+    ConfigSubsectionNexus,
     ConfigSectionSHM,
     ConfigSectionSRE,
+    ConfigSectionUserServices,
     ConfigSubsectionRemoteDesktopOpts,
     ConfigSubsectionStorageQuotaGB,
 )
@@ -112,6 +114,27 @@ class TestConfigSectionSHM:
             match=r"1 validation error for ConfigSectionSHM\nfqdn\n  Value error, Expected valid fully qualified domain name",
         ):
             ConfigSectionSHM(**config_section_shm_dict)
+
+
+class TestConfigSectionUserServices:
+    def test_constructor(self):
+        user_services_config = ConfigSectionUserServices(
+            nexus=ConfigSubsectionNexus(persistent_quota_gb=10)
+        )
+
+        assert user_services_config.nexus is not None
+        assert user_services_config.nexus.persistent_quota_gb == 10
+
+    def test_constructor_defaults(self):
+        user_services_config = ConfigSectionUserServices()
+        assert user_services_config.nexus is not None
+        assert user_services_config.nexus.persistent_quota_gb == 2
+
+    def test_invalid_nexus_quota(self):
+        with pytest.raises(ValueError, match="Input should be greater than 0"):
+            ConfigSectionUserServices(
+                nexus=ConfigSubsectionNexus(persistent_quota_gb=0)
+            )
 
 
 class TestConfigSectionSRE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,14 +537,15 @@ def sre_config_yaml(request):
             allow_copy: false
             allow_paste: false
         research_user_ip_addresses: []
-        service_quota_gb:
-            nexus: 2
         software_packages: none
         storage_quota_gb:
             home: 100
             shared: 100
         timezone: Europe/London
         workspace_skus: []
+    user_services:
+        nexus:
+            persistent_quota_gb: 2
     """.replace(
         "guid_subscription", request.config.guid_subscription
     ).replace(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -545,7 +545,7 @@ def sre_config_yaml(request):
         workspace_skus: []
     user_services:
         nexus:
-            persistent_quota_gb: 2
+            persistent_quota_gb: 10
     """.replace(
         "guid_subscription", request.config.guid_subscription
     ).replace(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,6 +537,8 @@ def sre_config_yaml(request):
             allow_copy: false
             allow_paste: false
         research_user_ip_addresses: []
+        service_quota_gb:
+            nexus: 2
         software_packages: none
         storage_quota_gb:
             home: 100


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

At the moment, the size of Nexus' persistent directory ---the `nexus-data` directory which corresponds to the File Share `software-repositories-nexus`--- is hard-coded to 2Gb, which is [insufficient in many cases](https://github.com/alan-turing-institute/data-safe-haven/issues/2434).
In this PR, we enable setting-up its size on the SRE's YAML configuration file.

We are proposing the following configuration:

```
user_services:
  nexus:
    persistent_quota_gb: 3
```

We believe this format will support, in the future, configuring other user services offered by the SRE (`Gitea`, `HedgeDoc`, or other `Nexus` properties), as well enabling/disabling them.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes https://github.com/alan-turing-institute/data-safe-haven/issues/2434

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
- We have deployed a Tier-2 SRE with a `persistent_quota_gb` of `3`, and verified in Portal that the file share reflects the user provided size.
- We have deployed a Tier-2 SRE  without the `user_services` section, and verified that the file share has the default size of `2Gb`.