### PR TITLE
Pin Click to version 8.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "azure-storage-file-datalake==12.18.1",
   "azure-storage-file-share==12.20.1",
   "chevron==0.14.0",
+  "click==8.1.8",
   "cryptography==44.0.2",
   "fqdn==1.5.1",
   "psycopg[binary]==3.1.19", # needed for installation on older MacOS versions


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

DSH currently has Typer pinned to version 0.15.2. Typer has Click as a dependency, but Typer 0.15.2 doesn't pin the Click version. Installing Typer 0.15.2 therefore, by default, results in Click 8.2.0 being installed (the latest version of Click as of now).

Unfortunately Typer 0.15.2 isn't compatible with Click 8.2.0. This change therefore pins Click to 8.1.8 in order to retain compatibility. Without this fix, calling "dsh --help" on a clean install results in an error.

Note that an alternative solution would be to upgrade the pinned version of Typer to 0.15.4, see [Issue #1215](https://github.com/fastapi/typer/discussions/1215) in the Typer repository. I didn't go down this route because I thought this would probably need more robust testing. But it's probably the better option.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2439

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

I've not tested this change. I've only performed a preliminary test by installing this version of Click manually in a virtual environment:

```
python3.12 -m venv venv
. ./venv/bin/activate
pip install --upgrade pip
pip install click==8.1.8
pip install data-safe-haven
```