### PR TITLE
Using the correct socket on the unit file for clamav-clamonacc

### DIFF
--- a/data_safe_haven/resources/workspace/ansible/files/etc/clamav/clamd.conf
+++ b/data_safe_haven/resources/workspace/ansible/files/etc/clamav/clamd.conf
@@ -1,5 +1,5 @@
 # Path to a local socket file the daemon will listen on.
-LocalSocket /tmp/clamd.socket
+LocalSocket /run/clamav/clamd.ctl
 # Sets the permissions on the unix socket to the specified mode.
 LocalSocketMode 660
 # Prevent access to infected files for normal users

--- a/data_safe_haven/resources/workspace/ansible/files/etc/systemd/system/clamav-clamonacc.service
+++ b/data_safe_haven/resources/workspace/ansible/files/etc/systemd/system/clamav-clamonacc.service
@@ -6,7 +6,6 @@ After=clamav-daemon.service syslog.target network.target
 [Service]
 Type=simple
 User=root
-ExecStartPre=/bin/bash -c "while [ ! -S /tmp/clamd.socket ]; do sleep 1; done"
 ExecStart=/usr/sbin/clamonacc --foreground=true
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on
N/A
<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

At the moment, `clamav.conf` states that the UNIX domain socket should be created at `/tmp/clamd.socket` and the unit file for `clamav-clamonacc` requires the socket file to start this service, otherwise it fails to start. When `clamav-clamonacc` fails to start, the Ansible playbook aborts and many services end misconfigured (like LDAP).

We verified, and other users have reported, that for the socket configuration in `clamav.conf` to take place  you need to restart or reconfigure the ClamAV daemon (see: https://github.com/alan-turing-institute/data-safe-haven/issues/2458  for evidence). However, a closer inspection of the ClamAV unit file shows that out-of-the-box a socket file is created at `/run/clamav/clamd.ctl` (managed by the `clamav-daemon.socket` unit file). The socket file is created before the daemon starts, and its ready to be used by the `clamav-clamonacc` service.

In this PR: 1) We indicate ClamaAV to use the `/run/clamav/clamd.ctl` file as local socket, 2) Remove the `ExecStartPre` logic from the `clamav-clamonacc` unit file, since this dependency is managed by `systemd`.

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

Closes https://github.com/alan-turing-institute/data-safe-haven/issues/2458 and https://github.com/alan-turing-institute/data-safe-haven/issues/2099

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

These are the results in at T2 SRE. After this changes were implemented:

`clamav-clamonacc` is active and running:

<img width="653" height="153" alt="image" src="https://github.com/user-attachments/assets/145c3d55-d9d0-421a-92e1-980f543c40c7" />

`clamav-daemon` is active and running:

<img width="463" height="159" alt="image" src="https://github.com/user-attachments/assets/72a6bd58-ef40-4fde-94d7-089c0571d6c8" />

The socket filed configured by `clamav-daemon.socket` is present:

<img width="490" height="249" alt="image" src="https://github.com/user-attachments/assets/74938c45-be66-48f5-bd8b-dcea6a6e0db8" />









<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
