### PR TITLE
Fix library update

### DIFF
--- a/data_safe_haven/infrastructure/components/composite/local_dns_record.py
+++ b/data_safe_haven/infrastructure/components/composite/local_dns_record.py
@@ -1,5 +1,5 @@
 from pulumi import ComponentResource, Input, Output, ResourceOptions
-from pulumi_azure_native import dns, network
+from pulumi_azure_native import dns, privatedns
 
 
 class LocalDnsRecordProps:
@@ -31,10 +31,10 @@ class LocalDnsRecordComponent(ComponentResource):
         child_opts = ResourceOptions.merge(opts, ResourceOptions(parent=self))
 
         # Register the resource in a private DNS zone
-        private_dns_record_set = network.PrivateRecordSet(
+        private_dns_record_set = privatedns.PrivateRecordSet(
             f"{self._name}_private_record_set",
             a_records=[
-                network.ARecordArgs(
+                privatedns.ARecordArgs(
                     ipv4_address=props.private_ip_address,
                 )
             ],
@@ -49,7 +49,7 @@ class LocalDnsRecordComponent(ComponentResource):
         # Redirect the public DNS to private DNS
         public_dns_record_set = dns.RecordSet(
             f"{self._name}_public_record_set",
-            cname_record=network.CnameRecordArgs(
+            cname_record=dns.CnameRecordArgs(
                 cname=Output.concat(props.record_name, ".privatelink.", props.base_fqdn)
             ),
             record_type="CNAME",

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -21,7 +21,6 @@ from .sre.application_gateway import (
     SREApplicationGatewayProps,
 )
 from .sre.apt_proxy_server import SREAptProxyServerComponent, SREAptProxyServerProps
-from .sre.backup import SREBackupComponent, SREBackupProps
 from .sre.clamav_mirror import SREClamAVMirrorComponent, SREClamAVMirrorProps
 from .sre.data import SREDataComponent, SREDataProps
 from .sre.desired_state import SREDesiredStateComponent, SREDesiredStateProps
@@ -420,20 +419,6 @@ class DeclarativeSRE:
                 vm_details=list(enumerate(self.config.sre.workspace_skus)),
             ),
             opts=ResourceOptions(depends_on=[desired_state]),
-            tags=self.tags,
-        )
-
-        # Deploy backup service
-        SREBackupComponent(
-            "sre_backup",
-            self.stack_name,
-            SREBackupProps(
-                location=self.config.azure.location,
-                resource_group_name=resource_group.name,
-                storage_account_data_private_sensitive_id=data.storage_account_data_private_sensitive_id,
-                storage_account_data_private_sensitive_name=data.storage_account_data_private_sensitive_name,
-                subscription_id=self.config.azure.subscription_id,
-            ),
             tags=self.tags,
         )
 

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -432,6 +432,7 @@ class DeclarativeSRE:
                 resource_group_name=resource_group.name,
                 storage_account_data_private_sensitive_id=data.storage_account_data_private_sensitive_id,
                 storage_account_data_private_sensitive_name=data.storage_account_data_private_sensitive_name,
+                subscription_id=self.config.azure.subscription_id,
             ),
             tags=self.tags,
         )

--- a/data_safe_haven/infrastructure/programs/sre/application_gateway.py
+++ b/data_safe_haven/infrastructure/programs/sre/application_gateway.py
@@ -81,7 +81,7 @@ class SREApplicationGatewayComponent(ComponentResource):
         dns.RecordSet(
             f"{self._name}_a_record",
             a_records=public_ip.ip_address.apply(
-                lambda ip: [network.ARecordArgs(ipv4_address=ip)] if ip else []
+                lambda ip: [dns.ARecordArgs(ipv4_address=ip)] if ip else []
             ),
             record_type="A",
             relative_record_set_name="@",

--- a/data_safe_haven/infrastructure/programs/sre/backup.py
+++ b/data_safe_haven/infrastructure/programs/sre/backup.py
@@ -179,7 +179,7 @@ class SREBackupComponent(ComponentResource):
             principal_type=authorization.PrincipalType.SERVICE_PRINCIPAL,
             role_assignment_name=str(
                 seeded_uuid(
-                    f"{stack_name} Storage Account Backup Contributor for Backup Value"
+                    f"{stack_name} Storage Account Backup Contributor for Backup Vault"
                 )
             ),
             role_definition_id=Output.concat(

--- a/data_safe_haven/infrastructure/programs/sre/backup.py
+++ b/data_safe_haven/infrastructure/programs/sre/backup.py
@@ -8,6 +8,8 @@ from pulumi_azure_native import authorization, dataprotection
 
 from data_safe_haven.functions import seeded_uuid
 
+# IMPORTANT: At the moment, this component is NOT deployed.
+
 
 class SREBackupProps:
     """Properties for SREBackupComponent"""

--- a/data_safe_haven/infrastructure/programs/sre/backup.py
+++ b/data_safe_haven/infrastructure/programs/sre/backup.py
@@ -1,9 +1,12 @@
 """Pulumi component for SRE backup"""
 
 from collections.abc import Mapping
+from typing import ClassVar
 
-from pulumi import ComponentResource, Input, ResourceOptions
-from pulumi_azure_native import dataprotection
+from pulumi import ComponentResource, Input, Output, ResourceOptions
+from pulumi_azure_native import authorization, dataprotection
+
+from data_safe_haven.functions import seeded_uuid
 
 
 class SREBackupProps:
@@ -15,6 +18,7 @@ class SREBackupProps:
         resource_group_name: Input[str],
         storage_account_data_private_sensitive_id: Input[str],
         storage_account_data_private_sensitive_name: Input[str],
+        subscription_id: Input[str],
     ) -> None:
         self.location = location
         self.resource_group_name = resource_group_name
@@ -24,10 +28,15 @@ class SREBackupProps:
         self.storage_account_data_private_sensitive_name = (
             storage_account_data_private_sensitive_name
         )
+        self.subscription_id = subscription_id
 
 
 class SREBackupComponent(ComponentResource):
     """Deploy SRE backup with Pulumi"""
+
+    azure_role_ids: ClassVar[dict[str, str]] = {
+        "Storage Account Backup Contributor": "e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1"
+    }
 
     def __init__(
         self,
@@ -160,6 +169,25 @@ class SREBackupComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts, ResourceOptions(parent=backup_vault)
             ),
+        )
+
+        authorization.RoleAssignment(
+            f"{self._name}_backup_instance_dns_zone_contributor_role_assignment",
+            principal_id=backup_vault.identity.principal_id,
+            principal_type=authorization.PrincipalType.SERVICE_PRINCIPAL,
+            role_assignment_name=str(
+                seeded_uuid(
+                    f"{stack_name} Storage Account Backup Contributor for Backup Value"
+                )
+            ),
+            role_definition_id=Output.concat(
+                "/subscriptions/",
+                props.subscription_id,
+                "/providers/Microsoft.Authorization/roleDefinitions/",
+                self.azure_role_ids["Storage Account Backup Contributor"],
+            ),
+            scope=props.storage_account_data_private_sensitive_id,
+            opts=child_opts,
         )
 
         # Backup instance for blobs

--- a/data_safe_haven/infrastructure/programs/sre/monitoring.py
+++ b/data_safe_haven/infrastructure/programs/sre/monitoring.py
@@ -122,6 +122,7 @@ class SREMonitoringComponent(ComponentResource):
         # Link the private linkscope to the log analytics workspace
         monitor.PrivateLinkScopedResource(
             f"{self._name}_log_analytics_ampls_connection",
+            kind=monitor.ScopedResourceKind.RESOURCE,
             linked_resource_id=self.log_analytics.id,
             name=f"{stack_name}-cnxn-ampls-to-log-analytics",
             resource_group_name=props.resource_group_name,
@@ -199,6 +200,7 @@ class SREMonitoringComponent(ComponentResource):
         # Link the private linkscope to the data collection endpoint
         monitor.PrivateLinkScopedResource(
             f"{self._name}_data_collection_endpoint_ampls_connection",
+            kind=monitor.ScopedResourceKind.RESOURCE,
             linked_resource_id=self.data_collection_endpoint.id,
             name=f"{stack_name}-cnxn-ampls-to-dce",
             resource_group_name=props.resource_group_name,

--- a/data_safe_haven/infrastructure/programs/sre/networking.py
+++ b/data_safe_haven/infrastructure/programs/sre/networking.py
@@ -1959,7 +1959,7 @@ class SRENetworkingComponent(ComponentResource):
             resource_group_name=props.shm_resource_group_name,
             zone_name=props.shm_zone_name,
         ).apply(
-            lambda kwargs: network.get_zone(
+            lambda kwargs: dns.get_zone(
                 resource_group_name=kwargs["resource_group_name"],
                 zone_name=kwargs["zone_name"],
                 opts=InvokeOptions(
@@ -1971,19 +1971,19 @@ class SRENetworkingComponent(ComponentResource):
             lambda name: alphanumeric(name).lower()
         )
         sre_fqdn = Output.concat(sre_subdomain, ".", props.shm_fqdn)
-        sre_dns_zone = network.Zone(
+        sre_dns_zone = dns.Zone(
             f"{self._name}_dns_zone",
             location="Global",
             resource_group_name=props.resource_group_name,
             zone_name=sre_fqdn,
-            zone_type=network.ZoneType.PUBLIC,
+            zone_type=dns.ZoneType.PUBLIC,
             opts=child_opts,
             tags=child_tags,
         )
         shm_ns_record = dns.RecordSet(
             f"{self._name}_ns_record",
             ns_records=sre_dns_zone.name_servers.apply(
-                lambda servers: [network.NsRecordArgs(nsdname=ns) for ns in servers]
+                lambda servers: [dns.NsRecordArgs(nsdname=ns) for ns in servers]
             ),
             record_type="NS",
             relative_record_set_name=sre_subdomain,
@@ -2001,7 +2001,7 @@ class SRENetworkingComponent(ComponentResource):
         dns.RecordSet(
             f"{self._name}_caa_record",
             caa_records=[
-                network.CaaRecordArgs(
+                dns.CaaRecordArgs(
                     flags=0,
                     tag="issue",
                     value="letsencrypt.org",


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [ ] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [ ] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [ ] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

A recent library update (see: https://github.com/alan-turing-institute/data-safe-haven/pull/2463/files ) broke the SRE deployment process. This PR fixes it.

Note that using updated versions of the library made deployment fail due to well-know problems with our backup system (see: https://github.com/alan-turing-institute/data-safe-haven/issues/2270 ) . As part of this PR, we remove the deployment of backup.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

We deployed a Tier-2 SRE from the current branch, and deployment succeeded: 

<img width="971" height="238" alt="image" src="https://github.com/user-attachments/assets/7612320d-a1b4-459a-8a84-1642691cadfc" />


