### PR TITLE
Disabling Guacamole Login

### DIFF
--- a/data_safe_haven/infrastructure/programs/sre/remote_desktop.py
+++ b/data_safe_haven/infrastructure/programs/sre/remote_desktop.py
@@ -197,6 +197,9 @@ class SRERemoteDesktopComponent(ComponentResource):
                     name="guacamole"[:63],
                     environment_variables=[
                         containerinstance.EnvironmentVariableArgs(
+                            name="EXTENSION_PRIORITY", value="openid"
+                        ),
+                        containerinstance.EnvironmentVariableArgs(
                             name="GUACD_HOSTNAME", value="localhost"
                         ),
                         containerinstance.EnvironmentVariableArgs(


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [ ] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [ ] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [ ] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

To ensure users use OpenID for authenticating in the SRE, Guacamole requires the `extension-priority` setting to have the value `openid` (see: https://guacamole.apache.org/doc/gug/openid-auth.html). In Docker, this setting is exposed via the `EXTENSION_PRIORITY` environment variable (see: https://guacamole.apache.org/doc/1.5.3/gug/guacamole-docker.html).

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes: https://github.com/alan-turing-institute/data-safe-haven/issues/2467

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested on a Tier-0 SRE.
