### PR TITLE
Add data disk support to workspaces

### DIFF
--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -8,6 +8,7 @@ from itertools import combinations
 from pydantic import BaseModel, HttpUrl, PositiveInt, field_validator, model_validator
 
 from data_safe_haven.types import (
+    AzureDataDiskSize,
     AzureLocation,
     AzurePremiumFileShareSize,
     AzureServiceTag,
@@ -49,6 +50,7 @@ class ConfigSubsectionRemoteDesktopOpts(BaseModel, validate_assignment=True):
 class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
     home: AzurePremiumFileShareSize
     shared: AzurePremiumFileShareSize
+    data_disk: AzureDataDiskSize = 0
 
 
 class ConfigSubsectionNexus(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -122,6 +122,7 @@ class SREConfig(AzureSerialisableModel):
                 storage_quota_gb=ConfigSubsectionStorageQuotaGB.model_construct(
                     home="Total size in GiB across all home directories [minimum: 100].",  # type: ignore
                     shared="Total size in GiB for the shared directories [minimum: 100].",  # type: ignore
+                    data_disk="Total size in GiB for the data disk [minimum: 0, maximum: 1023].",  # type: ignore
                 ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -187,6 +187,14 @@ class VMComponent(ComponentResource):
             os_profile=props.os_profile,
             resource_group_name=props.resource_group_name,
             storage_profile=compute.StorageProfileArgs(
+                # TODO(cgavidia): Only for testing
+                data_disks=[
+                    compute.DataDiskArgs(
+                        lun=0,
+                        create_option=compute.DiskCreateOption.EMPTY,
+                        disk_size_gb=4,
+                    )
+                ],
                 image_reference=props.image_reference,
                 os_disk=compute.OSDiskArgs(
                     caching=compute.CachingTypes.READ_WRITE,

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -175,7 +175,7 @@ class VMComponent(ComponentResource):
                 compute.DataDiskArgs(
                     lun=0,
                     create_option=compute.DiskCreateOption.EMPTY,
-                    disk_size_gb=4,
+                    disk_size_gb=props.data_disk_size,
                 )
             )
 

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -31,6 +31,7 @@ class VMComponentProps:
         admin_username: Input[str] | None = None,
         data_collection_rule_id: Input[str] | None = None,
         data_collection_endpoint_id: Input[str] | None = None,
+        data_disk_size: int = 0,
         ip_address_public: Input[bool] | None = None,
         maintenance_configuration_id: Input[str] | None = None,
     ) -> None:
@@ -41,6 +42,7 @@ class VMComponentProps:
             data_collection_rule_id
         ).apply(lambda rule_id: str(rule_id).split("/")[-1])
         self.data_collection_endpoint_id = data_collection_endpoint_id
+        self.data_disk_size = data_disk_size
         self.image_reference_args = None
         self.ip_address_private = ip_address_private
         self.ip_address_public = ip_address_public
@@ -166,6 +168,17 @@ class VMComponent(ComponentResource):
             tags=child_tags,
         )
 
+        # Define Data Disks
+        data_disks: list[compute.DataDiskArgs] = []
+        if props.data_disk_size > 0:
+            data_disks.append(
+                compute.DataDiskArgs(
+                    lun=0,
+                    create_option=compute.DiskCreateOption.EMPTY,
+                    disk_size_gb=4,
+                )
+            )
+
         # Define virtual machine
         virtual_machine = compute.VirtualMachine(
             name_underscored,
@@ -187,14 +200,7 @@ class VMComponent(ComponentResource):
             os_profile=props.os_profile,
             resource_group_name=props.resource_group_name,
             storage_profile=compute.StorageProfileArgs(
-                # TODO(cgavidia): Only for testing
-                data_disks=[
-                    compute.DataDiskArgs(
-                        lun=0,
-                        create_option=compute.DiskCreateOption.EMPTY,
-                        disk_size_gb=4,
-                    )
-                ],
+                data_disks=data_disks,
                 image_reference=props.image_reference,
                 os_disk=compute.OSDiskArgs(
                     caching=compute.CachingTypes.READ_WRITE,

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -219,7 +219,11 @@ class VMComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(
-                    delete_before_replace=True, replace_on_changes=["os_profile"]
+                    delete_before_replace=True,
+                    replace_on_changes=[
+                        "osProfile",
+                        "storageProfile.dataDisks[*].diskSizeGB",
+                    ],  # Pulumi's data disk update is limited by Azure https://github.com/pulumi/pulumi-azure-native/issues/3952
                 ),
             ),
             tags=child_tags,

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -458,7 +458,10 @@ class DeclarativeSRE:
                 subnet_workspaces=networking.subnet_workspaces,
                 subscription_name=sre_subscription_name,
                 virtual_network=networking.virtual_network,
-                vm_details=list(enumerate(self.config.sre.workspace_skus)),
+                vm_details=[
+                    (vm_index, vm_size, self.config.sre.storage_quota_gb.data_disk)
+                    for vm_index, vm_size in enumerate(self.config.sre.workspace_skus)
+                ],
             ),
             opts=ResourceOptions(depends_on=[desired_state]),
             tags=self.tags,

--- a/data_safe_haven/infrastructure/programs/sre/workspaces.py
+++ b/data_safe_haven/infrastructure/programs/sre/workspaces.py
@@ -36,7 +36,9 @@ class SREWorkspacesProps:
         subnet_workspaces: Input[network.GetSubnetResult],
         subscription_name: Input[str],
         virtual_network: Input[network.VirtualNetwork],
-        vm_details: list[tuple[int, str]],  # this must *not* be passed as an Input[T]
+        vm_details: list[
+            tuple[int, str, int]
+        ],  # this must *not* be passed as an Input[T]
     ) -> None:
         self.admin_password = Output.secret(admin_password)
         self.admin_username = "dshadmin"
@@ -94,6 +96,9 @@ class SREWorkspacesComponent(ComponentResource):
         # Load cloud-init file
         cloudinit = Output.all(
             apt_proxy_server_hostname=props.apt_proxy_server_hostname,
+            data_disk_support=any(
+                data_disk_size > 0 for _, _, data_disk_size in props.vm_details
+            ),
             storage_account_desired_state_name=props.storage_account_desired_state_name,
             storage_account_data_private_user_name=props.storage_account_data_private_user_name,
             storage_account_data_private_sensitive_name=props.storage_account_data_private_sensitive_name,
@@ -109,6 +114,7 @@ class SREWorkspacesComponent(ComponentResource):
                     b64cloudinit=cloudinit.apply(b64encode),
                     data_collection_rule_id=props.data_collection_rule_id,
                     data_collection_endpoint_id=props.data_collection_endpoint_id,
+                    data_disk_size=data_disk_size,
                     ip_address_private=props.vm_ip_addresses[vm_idx],
                     location=props.location,
                     maintenance_configuration_id=props.maintenance_configuration_id,
@@ -124,7 +130,7 @@ class SREWorkspacesComponent(ComponentResource):
                 opts=child_opts,
                 tags=child_tags,
             )
-            for vm_idx, vm_size in props.vm_details
+            for vm_idx, vm_size, data_disk_size in props.vm_details
         ]
 
         # Get details for each deployed VM

--- a/data_safe_haven/resources/workspace/ansible/desired_state.yaml
+++ b/data_safe_haven/resources/workspace/ansible/desired_state.yaml
@@ -51,6 +51,10 @@
       ansible.builtin.import_tasks: tasks/scratchpad.yaml
       tags: scratchpad
 
+    - name: Configure data disk
+      ansible.builtin.import_tasks: tasks/datadisk.yaml
+      tags: datadisk
+
     - name: Provision smoke tests
       ansible.builtin.import_tasks: tasks/smoke_tests.yaml
       tags: smoke_tests

--- a/data_safe_haven/resources/workspace/ansible/desired_state.yaml
+++ b/data_safe_haven/resources/workspace/ansible/desired_state.yaml
@@ -45,7 +45,7 @@
     - name: Configure package proxies
       ansible.builtin.import_tasks: tasks/package_proxy.yaml
       tags: package_proxies
-      when: use_software_repositories| bool
+      when: use_software_repositories | bool
 
     - name: Configure scratchpad
       ansible.builtin.import_tasks: tasks/scratchpad.yaml

--- a/data_safe_haven/resources/workspace/ansible/tasks/datadisk.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/datadisk.yaml
@@ -1,0 +1,14 @@
+---
+- name: Find data disk on Azure VM
+  ansible.builtin.stat:
+    path: /dev/disk/azure/scsi1/lun0
+  register: datadisk_disk_link
+
+- name: Set permissions of data disk directory
+  ansible.builtin.file:
+    path: /datadisk
+    state: directory
+    owner: root
+    group: root
+    mode: "0777"
+  when: datadisk_disk_link.stat.exists and datadisk_disk_link.stat.islnk

--- a/data_safe_haven/resources/workspace/ansible/tasks/datadisk.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/datadisk.yaml
@@ -6,7 +6,7 @@
 
 - name: Set permissions of data disk directory
   ansible.builtin.file:
-    path: /datadisk
+    path: /mnt/datadrive
     state: directory
     owner: root
     group: root

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -36,9 +36,22 @@ write_files:
       ansible-playbook desired_state.yaml
       popd
 
+disk_setup:
+  /dev/disk/azure/scsi1/lun0:
+    table_type: gpt
+    layout: True
+    overwrite: True
+
+fs_setup:
+  - device: /dev/disk/azure/scsi1/lun0
+    partition: 1
+    filesystem: ext4
+
 mounts:
   # Mount ephemeral storage at resource instead of default /mnt
   - [ephemeral0, /mnt/scratch]
+  # Mounting data disk
+  - ["/dev/disk/azure/scsi1/lun0-part1", "/datadisk", auto, "defaults,noexec,nofail"]
   # Desired state configuration is in a blob container mounted as NFSv3
   - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}/desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]
   # Secure data is in a blob container mounted as NFSv3

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -35,23 +35,25 @@ write_files:
       pushd /var/local/ansible
       ansible-playbook desired_state.yaml
       popd
-
+{{#data_disk_support}}
 disk_setup:
   /dev/disk/azure/scsi1/lun0:
     table_type: gpt
-    layout: True
-    overwrite: True
+    layout: true
+    overwrite: true
 
 fs_setup:
   - device: /dev/disk/azure/scsi1/lun0
     partition: "auto"
     filesystem: ext4
-
+{{/data_disk_support}}
 mounts:
   # Mount ephemeral storage at resource instead of default /mnt
   - [ephemeral0, /mnt/scratch]
+  {{#data_disk_support}}
   # Mounting data disk
-  - ["/dev/disk/azure/scsi1/lun0-part1", "/datadisk", auto, "defaults,noexec,nofail"]
+  - ["/dev/disk/azure/scsi1/lun0-part1", "/mnt/datadrive", auto, "defaults,noexec,nofail"]
+  {{/data_disk_support}}
   # Desired state configuration is in a blob container mounted as NFSv3
   - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}/desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]
   # Secure data is in a blob container mounted as NFSv3

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -44,7 +44,7 @@ disk_setup:
 
 fs_setup:
   - device: /dev/disk/azure/scsi1/lun0
-    partition: 1
+    partition: "auto"
     filesystem: ext4
 
 mounts:

--- a/data_safe_haven/types/__init__.py
+++ b/data_safe_haven/types/__init__.py
@@ -1,4 +1,5 @@
 from .annotated_types import (
+    AzureDataDiskSize,
     AzureLocation,
     AzurePremiumFileShareSize,
     AzureSubscriptionName,
@@ -34,6 +35,7 @@ from .types import PathType
 
 __all__ = [
     "AllowlistRepository",
+    "AzureDataDiskSize",
     "AzureDnsZoneNames",
     "AzureLocation",
     "AzurePremiumFileShareSize",

--- a/data_safe_haven/types/annotated_types.py
+++ b/data_safe_haven/types/annotated_types.py
@@ -1,12 +1,13 @@
 from collections.abc import Hashable
 from typing import Annotated, TypeAlias, TypeVar
 
-from annotated_types import Ge
+from annotated_types import Ge, Le
 from pydantic import Field
 from pydantic.functional_validators import AfterValidator
 
 from data_safe_haven import validators
 
+AzureDataDiskSize = Annotated[int, Le(1023)]
 AzureLocation = Annotated[str, AfterValidator(validators.azure_location)]
 AzurePremiumFileShareSize = Annotated[int, Ge(100)]
 AzureShortName = Annotated[str, Field(min_length=1, max_length=24)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,8 +193,8 @@ def context_yaml() -> str:
 
 @fixture
 def local_project_settings(
-    context_no_secrets: Context, mocker: MockerFixture
-) -> None:  # noqa: ARG001
+    context_no_secrets: Context, mocker: MockerFixture  # noqa: ARG001
+) -> None:
     """Overwrite adjust project settings to work locally, no secrets"""
     mocker.patch.object(
         ProjectManager,
@@ -349,12 +349,12 @@ def mock_key_vault_key(monkeypatch: MonkeyPatch) -> None:
             self.key_vault_name = key_vault_name
             self.id = "mock_key/version"
 
-    def mock_get_keyvault_key(
-        self, key_name, key_vault_name
-    ) -> MockKeyVaultKey:  # noqa: ARG001
-        return MockKeyVaultKey(key_name, key_vault_name)
+        def mock_get_keyvault_key(self, key_name, key_vault_name):
+            return MockKeyVaultKey(key_name, key_vault_name)
 
-    monkeypatch.setattr(AzureSdk, "get_keyvault_key", mock_get_keyvault_key)
+    monkeypatch.setattr(
+        AzureSdk, "get_keyvault_key", MockKeyVaultKey.mock_get_keyvault_key
+    )
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from azure.core.credentials import AccessToken, TokenCredential
 from azure.mgmt.resource.subscriptions.models import Subscription
 from pulumi.automation import ProjectSettings
 from pytest import FixtureRequest, MonkeyPatch, fixture
+from pytest_mock import MockerFixture, MockType
 
 import data_safe_haven.config.context_manager as context_mod
 import data_safe_haven.logging.logger
@@ -191,7 +192,9 @@ def context_yaml() -> str:
 
 
 @fixture
-def local_project_settings(context_no_secrets: Context, mocker) -> None:  # noqa: ARG001
+def local_project_settings(
+    context_no_secrets: Context, mocker: MockerFixture
+) -> None:  # noqa: ARG001
     """Overwrite adjust project settings to work locally, no secrets"""
     mocker.patch.object(
         ProjectManager,
@@ -225,7 +228,7 @@ def log_directory(session_mocker, tmp_path_factory):
 
 
 @fixture
-def mock_azuresdk_blob_exists(mocker):
+def mock_azuresdk_blob_exists(mocker: MockerFixture) -> None:
     mocker.patch.object(
         AzureSdk,
         "blob_exists",
@@ -234,7 +237,9 @@ def mock_azuresdk_blob_exists(mocker):
 
 
 @fixture
-def mock_azuresdk_get_subscription(mocker, request: FixtureRequest) -> None:
+def mock_azuresdk_get_subscription(
+    mocker: MockerFixture, request: FixtureRequest
+) -> None:
     subscription = Subscription()
     subscription.display_name = "Data Safe Haven Acme"
     subscription.subscription_id = request.config.guid_subscription
@@ -247,7 +252,7 @@ def mock_azuresdk_get_subscription(mocker, request: FixtureRequest) -> None:
 
 
 @fixture
-def mock_azuresdk_get_subscription_name(mocker):
+def mock_azuresdk_get_subscription_name(mocker: MockerFixture) -> None:
     mocker.patch.object(
         AzureSdk,
         "get_subscription_name",
@@ -256,7 +261,7 @@ def mock_azuresdk_get_subscription_name(mocker):
 
 
 @fixture
-def mock_graphapi_get_credential(mocker):
+def mock_graphapi_get_credential(mocker: MockerFixture) -> None:
     class MockCredential(TokenCredential):
         def get_token(*args, **kwargs):  # noqa: ARG002
             return AccessToken("dummy-token", 0)
@@ -269,9 +274,9 @@ def mock_graphapi_get_credential(mocker):
 
 
 @fixture
-def mock_azuresdk_get_credential(mocker):
+def mock_azuresdk_get_credential(mocker: MockerFixture) -> None:
     class MockCredential(TokenCredential):
-        def get_token(*args, **kwargs):  # noqa: ARG002
+        def get_token(*args, **kwargs) -> AccessToken:  # noqa: ARG002
             return AccessToken("dummy-token", 0)
 
     mocker.patch.object(
@@ -282,8 +287,8 @@ def mock_azuresdk_get_credential(mocker):
 
 
 @fixture
-def mock_azuresdk_get_credential_failure(mocker):
-    def fail_get_credential():
+def mock_azuresdk_get_credential_failure(mocker: MockerFixture) -> None:
+    def fail_get_credential() -> DataSafeHavenAzureError:
         print("mock get_credential")  # noqa: T201
         msg = "mock get_credential error"
         raise DataSafeHavenAzureError(msg)
@@ -296,7 +301,7 @@ def mock_azuresdk_get_credential_failure(mocker):
 
 
 @fixture
-def mock_azuresdk_purge_keyvault(mocker):
+def mock_azuresdk_purge_keyvault(mocker: MockerFixture) -> None:
     mocker.patch.object(
         AzureSdk,
         "purge_keyvault",
@@ -305,7 +310,7 @@ def mock_azuresdk_purge_keyvault(mocker):
 
 
 @fixture
-def mock_azuresdk_remove_blob(mocker):
+def mock_azuresdk_remove_blob(mocker: MockerFixture) -> None:
     mocker.patch.object(
         AzureSdk,
         "remove_blob",
@@ -314,7 +319,7 @@ def mock_azuresdk_remove_blob(mocker):
 
 
 @fixture
-def mock_confirm_no(mocker):
+def mock_confirm_no(mocker: MockerFixture) -> MockType:
     return mocker.patch.object(
         console,
         "confirm",
@@ -323,7 +328,7 @@ def mock_confirm_no(mocker):
 
 
 @fixture
-def mock_confirm_yes(mocker):
+def mock_confirm_yes(mocker: MockerFixture) -> MockType:
     return mocker.patch.object(
         console,
         "confirm",
@@ -332,26 +337,28 @@ def mock_confirm_yes(mocker):
 
 
 @fixture
-def mock_install_plugins(mocker):
+def mock_install_plugins(mocker: MockerFixture) -> None:
     mocker.patch.object(ProjectManager, "install_plugins", return_value=None)
 
 
 @fixture
 def mock_key_vault_key(monkeypatch: MonkeyPatch) -> None:
     class MockKeyVaultKey:
-        def __init__(self, key_name, key_vault_name):
+        def __init__(self, key_name, key_vault_name) -> None:
             self.key_name = key_name
             self.key_vault_name = key_vault_name
             self.id = "mock_key/version"
 
-    def mock_get_keyvault_key(self, key_name, key_vault_name) -> MockKeyVaultKey:  # noqa: ARG001
+    def mock_get_keyvault_key(
+        self, key_name, key_vault_name
+    ) -> MockKeyVaultKey:  # noqa: ARG001
         return MockKeyVaultKey(key_name, key_vault_name)
 
     monkeypatch.setattr(AzureSdk, "get_keyvault_key", mock_get_keyvault_key)
 
 
 @fixture
-def mock_storage_exists(mocker):
+def mock_storage_exists(mocker: MockerFixture) -> MockType:
     return mocker.patch.object(
         AzureSdk,
         "storage_exists",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import yaml
 from azure.core.credentials import AccessToken, TokenCredential
 from azure.mgmt.resource.subscriptions.models import Subscription
 from pulumi.automation import ProjectSettings
-from pytest import fixture
+from pytest import FixtureRequest, MonkeyPatch, fixture
 
 import data_safe_haven.config.context_manager as context_mod
 import data_safe_haven.logging.logger
@@ -38,7 +38,7 @@ from data_safe_haven.infrastructure.project_manager import ProjectManager
 from data_safe_haven.logging import init_logging
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     """Define constants for use across multiple tests"""
     config.guid_admin = "00edec65-b071-4d26-8779-a9fe791c6e14"
     config.guid_application = "aa78dceb-4116-4713-8554-cf2b3027e119"
@@ -49,7 +49,7 @@ def pytest_configure(config):
 
 
 @fixture
-def config_section_azure(request):
+def config_section_azure(request: FixtureRequest) -> ConfigSectionAzure:
     return ConfigSectionAzure(
         location="uksouth",
         subscription_id=request.config.guid_subscription,
@@ -58,12 +58,12 @@ def config_section_azure(request):
 
 
 @fixture
-def config_section_shm(config_section_shm_dict):
+def config_section_shm(config_section_shm_dict: dict[str, str]) -> ConfigSectionSHM:
     return ConfigSectionSHM(**config_section_shm_dict)
 
 
 @fixture
-def config_section_shm_dict(request):
+def config_section_shm_dict(request: FixtureRequest) -> dict[str, str]:
     return {
         "admin_group_id": request.config.guid_admin,
         "entra_tenant_id": request.config.guid_entra,
@@ -81,7 +81,8 @@ def config_section_dockerhub() -> ConfigSectionDockerHub:
 
 @fixture
 def config_section_sre(
-    config_subsection_remote_desktop, config_subsection_storage_quota_gb
+    config_subsection_remote_desktop: ConfigSubsectionRemoteDesktopOpts,
+    config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
 ) -> ConfigSectionSRE:
     return ConfigSectionSRE(
         admin_email_address="admin@example.com",
@@ -95,7 +96,8 @@ def config_section_sre(
 
 @fixture
 def config_section_sre_allow_internet(
-    config_subsection_remote_desktop, config_subsection_storage_quota_gb
+    config_subsection_remote_desktop: ConfigSubsectionRemoteDesktopOpts,
+    config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
 ) -> ConfigSectionSRE:
     return ConfigSectionSRE(
         admin_email_address="admin@example.com",
@@ -110,7 +112,8 @@ def config_section_sre_allow_internet(
 
 @fixture
 def config_section_sre_any_packages(
-    config_subsection_remote_desktop, config_subsection_storage_quota_gb
+    config_subsection_remote_desktop: ConfigSubsectionRemoteDesktopOpts,
+    config_subsection_storage_quota_gb: ConfigSubsectionStorageQuotaGB,
 ) -> ConfigSectionSRE:
     return ConfigSectionSRE(
         admin_email_address="admin@example.com",
@@ -133,12 +136,12 @@ def config_subsection_storage_quota_gb() -> ConfigSubsectionStorageQuotaGB:
 
 
 @fixture
-def context(context_dict):
+def context(context_dict: dict[str, str]) -> Context:
     return Context(**context_dict)
 
 
 @fixture
-def context_dict():
+def context_dict() -> dict[str, str]:
     return {
         "admin_group_name": "Acme Admins",
         "description": "Acme Deployment",
@@ -148,24 +151,28 @@ def context_dict():
 
 
 @fixture
-def context_no_secrets(monkeypatch, context_dict) -> Context:
+def context_no_secrets(
+    monkeypatch: MonkeyPatch, context_dict: dict[str, str]
+) -> Context:
     monkeypatch.setattr(Context, "pulumi_secrets_provider_url", None)
     return Context(**context_dict)
 
 
 @fixture
-def context_manager(context_yaml) -> ContextManager:
+def context_manager(context_yaml: str) -> ContextManager:
     return ContextManager.from_yaml(context_yaml)
 
 
 @fixture
-def context_tmpdir(context_dict, tmpdir, monkeypatch) -> tuple[Context, Path]:
+def context_tmpdir(
+    context_dict: dict[str, str], tmpdir, monkeypatch: MonkeyPatch
+) -> tuple[Context, Path]:
     monkeypatch.setattr(context_mod, "config_dir", lambda: Path(tmpdir))
     return (Context(**context_dict), tmpdir)
 
 
 @fixture
-def context_yaml():
+def context_yaml() -> str:
     content = """---
     selected: acmedeployment
     contexts:
@@ -184,7 +191,7 @@ def context_yaml():
 
 
 @fixture
-def local_project_settings(context_no_secrets, mocker):  # noqa: ARG001
+def local_project_settings(context_no_secrets: Context, mocker) -> None:  # noqa: ARG001
     """Overwrite adjust project settings to work locally, no secrets"""
     mocker.patch.object(
         ProjectManager,
@@ -227,7 +234,7 @@ def mock_azuresdk_blob_exists(mocker):
 
 
 @fixture
-def mock_azuresdk_get_subscription(mocker, request):
+def mock_azuresdk_get_subscription(mocker, request: FixtureRequest) -> None:
     subscription = Subscription()
     subscription.display_name = "Data Safe Haven Acme"
     subscription.subscription_id = request.config.guid_subscription
@@ -330,14 +337,14 @@ def mock_install_plugins(mocker):
 
 
 @fixture
-def mock_key_vault_key(monkeypatch):
+def mock_key_vault_key(monkeypatch: MonkeyPatch) -> None:
     class MockKeyVaultKey:
         def __init__(self, key_name, key_vault_name):
             self.key_name = key_name
             self.key_vault_name = key_vault_name
             self.id = "mock_key/version"
 
-    def mock_get_keyvault_key(self, key_name, key_vault_name):  # noqa: ARG001
+    def mock_get_keyvault_key(self, key_name, key_vault_name) -> MockKeyVaultKey:  # noqa: ARG001
         return MockKeyVaultKey(key_name, key_vault_name)
 
     monkeypatch.setattr(AzureSdk, "get_keyvault_key", mock_get_keyvault_key)
@@ -353,7 +360,7 @@ def mock_storage_exists(mocker):
 
 
 @fixture
-def offline_pulumi_account(monkeypatch):
+def offline_pulumi_account(monkeypatch: MonkeyPatch) -> None:
     """Overwrite PulumiAccount so that it runs locally"""
     monkeypatch.setattr(
         PulumiAccount, "env", {"PULUMI_CONFIG_PASSPHRASE": "passphrase"}
@@ -398,7 +405,7 @@ def pulumi_config_no_key(
 
 
 @fixture
-def pulumi_project(pulumi_project_stack_config) -> DSHPulumiProject:
+def pulumi_project(pulumi_project_stack_config: dict[str, str]) -> DSHPulumiProject:
     return DSHPulumiProject(
         stack_config=pulumi_project_stack_config,
     )
@@ -427,7 +434,7 @@ def pulumi_project_sandbox() -> DSHPulumiProject:
 
 
 @fixture
-def pulumi_project_stack_config():
+def pulumi_project_stack_config() -> dict[str, str]:
     return {
         "azure-native:location": "uksouth",
         "azure-native:subscriptionId": "abc",
@@ -484,7 +491,7 @@ def shm_config_file(shm_config_yaml: str, tmp_path: Path) -> Path:
 
 
 @fixture
-def shm_config_yaml(request):
+def shm_config_yaml(request: FixtureRequest) -> str:
     content = (
         """---
     azure:
@@ -506,7 +513,7 @@ def shm_config_yaml(request):
 
 
 @fixture
-def sre_config_file(sre_config_yaml, tmp_path):
+def sre_config_file(sre_config_yaml: str, tmp_path: Path) -> Path:
     config_file_path = tmp_path / "config.yaml"
     with open(config_file_path, "w") as f:
         f.write(sre_config_yaml)
@@ -592,7 +599,7 @@ def sre_config_alternate(
 
 
 @fixture
-def sre_config_yaml(request):
+def sre_config_yaml(request: FixtureRequest) -> str:
     content = """---
     azure:
         location: uksouth
@@ -641,21 +648,21 @@ def sre_config_yaml(request):
 
 
 @fixture
-def sre_config_yaml_missing_field(sre_config_yaml):
+def sre_config_yaml_missing_field(sre_config_yaml: str) -> str:
     content = sre_config_yaml.replace("admin_email_address: admin@example.com", "")
     return yaml.dump(yaml.safe_load(content))
 
 
 @fixture
 def sre_project_manager(
-    context_no_secrets,
-    sre_config,
-    pulumi_config_no_key,
+    context_no_secrets: Context,
+    sre_config: SREConfig,
+    pulumi_config_no_key: DSHPulumiConfig,
     local_project_settings,  # noqa: ARG001
     mock_azuresdk_get_subscription,  # noqa: ARG001
     mock_azuresdk_get_credential,  # noqa: ARG001
     offline_pulumi_account,  # noqa: ARG001
-):
+) -> SREProjectManager:
     return SREProjectManager(
         context=context_no_secrets,
         config=sre_config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -618,6 +618,7 @@ def sre_config_yaml(request):
         storage_quota_gb:
             home: 100
             shared: 100
+            data_disk: 0
         timezone: Europe/London
         workspace_skus: []
     user_services:


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A

### :arrow_heading_up: Summary

As discussed in https://github.com/alan-turing-institute/data-safe-haven/issues/2490, using development tools from the TRE's NFS locations (like `home`) is very slow, and a suitable workaround is using disks directly attached to the VMs. At the moment, some VM SKUs use temporary storage mounted at `/mnt/scratch` that can address this (see: https://github.com/alan-turing-institute/data-safe-haven/pull/2432 ), but this storage is ephemeral and not available to all SKUs. As part of the PR, we're given this performance boost to every VM SKU permanently, by [allowing attaching data disks](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/attach-disk-portal) to workspaces.

To accomplish this, we did the following:

* We added a new entry to the TRE config file. If `data_disk` has a value bigger than 0, we would attach empty data disks to the workspaces with that size (see `config_sections.py` and `virtual_machines.py`). For example, to attach a 4GB data disk to a TRE VMs, we would use:
```yaml
  storage_quota_gb:
    home: 100
    shared: 100
    data_disk: 4
  timezone: Europe/London
  workspace_skus:
    - Standard_D2ds_v5
```
* We use cloud-init (see `workspace.cloud_init.mustache.yaml`) for defining, configuring and mounting the disk to `/mnt/datadrive`, following the guidance from the cloud-init documentation (see: https://cloudinit.readthedocs.io/en/latest/reference/yaml_examples/disk_setup.html#data-disks-definitions-for-microsoft-azure). We are only doing this for TREs with data disks defined.
* We configure datadisk permissions using Ansible (see `desired_state.yaml` and `datadisk.yaml`) only if the Azure disk symlinks is present (as done in https://learn.microsoft.com/en-us/azure/virtual-machines/linux/add-disk?tabs=lsblk). The permission are the same as the `shared` and `scratch` directories.



<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

Closes https://github.com/alan-turing-institute/data-safe-haven/issues/2490
<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

In a sandbox SRE, we verified that the data disk was created and attached to the VM:

<img width="1235" height="477" alt="image" src="https://github.com/user-attachments/assets/5e6403fa-9793-49ed-b8fc-0257f768f288" />

From a workspace, we can verify that the disk was mounted at `/mnt/datadrive`, with `LUN` 0:

<img width="769" height="209" alt="image" src="https://github.com/user-attachments/assets/23a50064-fbbb-4bcd-9dcd-33096064ea3e" />

And `/mnt/datadrive` have the right permissions, allowing SRE users to write on it:
<img width="535" height="152" alt="image" src="https://github.com/user-attachments/assets/b78df028-253c-4f83-b862-fbc4ed804022" />




