### PR TITLE
Use correct subscription with allowlists

### DIFF
--- a/data_safe_haven/commands/allowlist.py
+++ b/data_safe_haven/commands/allowlist.py
@@ -9,6 +9,7 @@ from data_safe_haven import console
 from data_safe_haven.allowlist import Allowlist
 from data_safe_haven.config import ContextManager, DSHPulumiConfig, SREConfig
 from data_safe_haven.exceptions import DataSafeHavenConfigError, DataSafeHavenError
+from data_safe_haven.external import AzureSdk
 from data_safe_haven.infrastructure import SREProjectManager
 from data_safe_haven.logging import get_logger
 from data_safe_haven.types import AllowlistRepository, SoftwarePackageCategory
@@ -82,6 +83,11 @@ def show(
         context=context,
         config=sre_config,
         pulumi_config=pulumi_config,
+    )
+
+    azure_sdk = AzureSdk(subscription_name=context.subscription_name)
+    context.subscription_name = azure_sdk.get_subscription_name(
+        sre_config.azure.subscription_id
     )
 
     try:
@@ -182,6 +188,11 @@ def upload(
 
     local_allowlist = Allowlist(
         repository=repository, sre_stack=sre_stack, allowlist=allowlist
+    )
+
+    azure_sdk = AzureSdk(subscription_name=context.subscription_name)
+    context.subscription_name = azure_sdk.get_subscription_name(
+        sre_config.azure.subscription_id
     )
 
     if not force and Allowlist.remote_exists(

--- a/tests/commands/test_allowlist.py
+++ b/tests/commands/test_allowlist.py
@@ -58,6 +58,9 @@ class TestShowAllowlist:
         sre_name = "sandbox"
         repository = "cran"
         mocker.patch.object(Allowlist, "from_remote", return_value=mock_allowlist)
+        mocker.patch.object(
+            AzureSdk, "get_subscription_name", return_value="Subscription name"
+        )
         result = runner.invoke(
             allowlist_command_group,
             ["show", sre_name, repository],
@@ -82,6 +85,9 @@ class TestShowAllowlist:
             SREConfig, "from_remote_by_name", return_value=sre_config_any_packages
         )
         mocker.patch.object(Allowlist, "from_remote", return_value=mock_allowlist)
+        mocker.patch.object(
+            AzureSdk, "get_subscription_name", return_value="Subscription name"
+        )
         result = runner.invoke(
             allowlist_command_group,
             ["show", sre_name, repository],
@@ -143,6 +149,9 @@ class TestUploadAllowlist:
 
         mocker.patch.object(Allowlist, "remote_exists", return_value=False)
         mocker.patch.object(AzureSdk, "upload_file_share", return_value=None)
+        mocker.patch.object(
+            AzureSdk, "get_subscription_name", return_value="Subscription name"
+        )
 
         result = runner.invoke(
             allowlist_command_group,
@@ -179,6 +188,9 @@ class TestUploadAllowlist:
         mocker.patch.object(Allowlist, "remote_exists", return_value=True)
         mocker.patch.object(Allowlist, "from_remote", return_value=mock_allowlist)
         mocker.patch.object(Allowlist, "diff", return_value=[])
+        mocker.patch.object(
+            AzureSdk, "get_subscription_name", return_value="Subscription name"
+        )
 
         result = runner.invoke(
             allowlist_command_group,
@@ -210,6 +222,9 @@ class TestUploadAllowlist:
         mocker.patch.object(Allowlist, "remote_exists", return_value=True)
         mocker.patch.object(Allowlist, "from_remote", return_value=mock_allowlist)
         mocker.patch.object(Allowlist, "diff", return_value=["-numpy", "+pandas"])
+        mocker.patch.object(
+            AzureSdk, "get_subscription_name", return_value="Subscription name"
+        )
 
         result = runner.invoke(
             allowlist_command_group,


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

Nothing.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

When handling allowlists, upload and download should happen from the SRE subscription rather than the SHM subscription.

This code ensures the SRE subscription name is used when making the relevant Azure calls rather than the SHM subscription when uploading or downloading an allowlist.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Fixes #2431.

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

> [!IMPORTANT]
> I've tested the download code (`dsh allowlist show`) on a deployed SRE but not the upload code (`dsh allowlist upload`) since I only have easy access to a production deployment.
