### PR TITLE
Adding support for OS disk size specification on TRE config file.

### DIFF
--- a/data_safe_haven/config/config_sections.py
+++ b/data_safe_haven/config/config_sections.py
@@ -51,6 +51,7 @@ class ConfigSubsectionStorageQuotaGB(BaseModel, validate_assignment=True):
     home: AzurePremiumFileShareSize
     shared: AzurePremiumFileShareSize
     data_disk: AzureDataDiskSize = 0
+    os_disk: AzureDataDiskSize = 64
 
 
 class ConfigSubsectionNexus(BaseModel, validate_assignment=True):

--- a/data_safe_haven/config/sre_config.py
+++ b/data_safe_haven/config/sre_config.py
@@ -123,6 +123,7 @@ class SREConfig(AzureSerialisableModel):
                     home="Total size in GiB across all home directories [minimum: 100].",  # type: ignore
                     shared="Total size in GiB for the shared directories [minimum: 100].",  # type: ignore
                     data_disk="Total size in GiB for the data disk [minimum: 0, maximum: 1023].",  # type: ignore
+                    os_disk="Total size in GiB for the OS disk [minimum: 64, maximum: 1023].",  # type: ignore
                 ),
                 timezone="Timezone in pytz format (eg. Europe/London)",
                 workspace_skus=[

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -31,9 +31,10 @@ class VMComponentProps:
         admin_username: Input[str] | None = None,
         data_collection_rule_id: Input[str] | None = None,
         data_collection_endpoint_id: Input[str] | None = None,
-        data_disk_size: int = 0,
+        data_disk_size: Input[int] = 0,
         ip_address_public: Input[bool] | None = None,
         maintenance_configuration_id: Input[str] | None = None,
+        os_disk_size: Input[int] = 64,
     ) -> None:
         self.admin_password = admin_password
         self.admin_username = admin_username if admin_username else "dshvmadmin"
@@ -48,6 +49,7 @@ class VMComponentProps:
         self.ip_address_public = ip_address_public
         self.location = location
         self.maintenance_configuration_id = maintenance_configuration_id
+        self.os_disk_size = os_disk_size
         self.os_profile_args = None
         self.resource_group_name = resource_group_name
         self.subnet_name = subnet_name
@@ -198,13 +200,14 @@ class VMComponent(ComponentResource):
                 ],
             ),
             os_profile=props.os_profile,
-            resource_group_name=props.resource_group_name,
+        resource_group_name=props.resource_group_name,
             storage_profile=compute.StorageProfileArgs(
                 data_disks=data_disks,
                 image_reference=props.image_reference,
                 os_disk=compute.OSDiskArgs(
                     caching=compute.CachingTypes.READ_WRITE,
                     create_option=compute.DiskCreateOptionTypes.FROM_IMAGE,
+                    disk_size_gb=props.os_disk_size,
                     delete_option=compute.DiskDeleteOptionTypes.DELETE,
                     managed_disk=compute.ManagedDiskParametersArgs(
                         storage_account_type=compute.StorageAccountTypes.PREMIUM_LRS,

--- a/data_safe_haven/infrastructure/components/composite/virtual_machine.py
+++ b/data_safe_haven/infrastructure/components/composite/virtual_machine.py
@@ -182,6 +182,8 @@ class VMComponent(ComponentResource):
             )
 
         # Define virtual machine
+        # IMPORTANT! Updating the size of either the OS/Data disk is not possible due to Pulumi limitations.
+        # These changes need to happen manually after VM deallocation (see: https://github.com/pulumi/pulumi-azure-native/issues/3952)
         virtual_machine = compute.VirtualMachine(
             name_underscored,
             diagnostics_profile=compute.DiagnosticsProfileArgs(
@@ -200,7 +202,7 @@ class VMComponent(ComponentResource):
                 ],
             ),
             os_profile=props.os_profile,
-        resource_group_name=props.resource_group_name,
+            resource_group_name=props.resource_group_name,
             storage_profile=compute.StorageProfileArgs(
                 data_disks=data_disks,
                 image_reference=props.image_reference,
@@ -225,8 +227,7 @@ class VMComponent(ComponentResource):
                     delete_before_replace=True,
                     replace_on_changes=[
                         "osProfile",
-                        "storageProfile.dataDisks[*].diskSizeGB",
-                    ],  # Pulumi's data disk update is limited by Azure https://github.com/pulumi/pulumi-azure-native/issues/3952
+                    ],
                 ),
             ),
             tags=child_tags,

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -459,7 +459,12 @@ class DeclarativeSRE:
                 subscription_name=sre_subscription_name,
                 virtual_network=networking.virtual_network,
                 vm_details=[
-                    (vm_index, vm_size, self.config.sre.storage_quota_gb.data_disk)
+                    (
+                        vm_index,
+                        vm_size,
+                        self.config.sre.storage_quota_gb.data_disk,
+                        self.config.sre.storage_quota_gb.os_disk,
+                    )
                     for vm_index, vm_size in enumerate(self.config.sre.workspace_skus)
                 ],
             ),

--- a/data_safe_haven/infrastructure/programs/sre/workspaces.py
+++ b/data_safe_haven/infrastructure/programs/sre/workspaces.py
@@ -37,7 +37,7 @@ class SREWorkspacesProps:
         subscription_name: Input[str],
         virtual_network: Input[network.VirtualNetwork],
         vm_details: list[
-            tuple[int, str, int]
+            tuple[int, str, int, int]
         ],  # this must *not* be passed as an Input[T]
     ) -> None:
         self.admin_password = Output.secret(admin_password)
@@ -97,7 +97,7 @@ class SREWorkspacesComponent(ComponentResource):
         cloudinit = Output.all(
             apt_proxy_server_hostname=props.apt_proxy_server_hostname,
             data_disk_support=any(
-                data_disk_size > 0 for _, _, data_disk_size in props.vm_details
+                data_disk_size > 0 for _, _, data_disk_size, _ in props.vm_details
             ),
             storage_account_desired_state_name=props.storage_account_desired_state_name,
             storage_account_data_private_user_name=props.storage_account_data_private_user_name,
@@ -118,6 +118,7 @@ class SREWorkspacesComponent(ComponentResource):
                     ip_address_private=props.vm_ip_addresses[vm_idx],
                     location=props.location,
                     maintenance_configuration_id=props.maintenance_configuration_id,
+                    os_disk_size=os_disk_size,
                     resource_group_name=props.resource_group_name,
                     subnet_name=props.subnet_workspaces_name,
                     virtual_network_name=props.virtual_network_name,
@@ -130,7 +131,7 @@ class SREWorkspacesComponent(ComponentResource):
                 opts=child_opts,
                 tags=child_tags,
             )
-            for vm_idx, vm_size, data_disk_size in props.vm_details
+            for vm_idx, vm_size, data_disk_size, os_disk_size in props.vm_details
         ]
 
         # Get details for each deployed VM

--- a/tests/config/test_shm_config.py
+++ b/tests/config/test_shm_config.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from pytest_mock import MockerFixture
 
 from data_safe_haven.config import Context, SHMConfig
 from data_safe_haven.config.config_sections import (
@@ -53,7 +54,11 @@ class TestConfig:
         assert isinstance(config.shm.fqdn, str)
 
     def test_from_remote(
-        self, mocker, context, shm_config: SHMConfig, shm_config_yaml
+        self,
+        mocker: MockerFixture,
+        context: Context,
+        shm_config: SHMConfig,
+        shm_config_yaml: str,
     ) -> None:
         mock_method = mocker.patch.object(
             AzureSdk, "download_blob", return_value=shm_config_yaml
@@ -68,10 +73,12 @@ class TestConfig:
             context.storage_container_name,
         )
 
-    def test_to_yaml(self, shm_config: SHMConfig, shm_config_yaml) -> None:
+    def test_to_yaml(self, shm_config: SHMConfig, shm_config_yaml: str) -> None:
         assert shm_config.to_yaml() == shm_config_yaml
 
-    def test_upload(self, mocker, context: Context, shm_config: SHMConfig) -> None:
+    def test_upload(
+        self, mocker: MockerFixture, context: Context, shm_config: SHMConfig
+    ) -> None:
         mock_method = mocker.patch.object(AzureSdk, "upload_blob", return_value=None)
         shm_config.upload(context)
 

--- a/tests/config/test_sre_config.py
+++ b/tests/config/test_sre_config.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from pytest_mock import MockerFixture
 
 from data_safe_haven.config import Context, SREConfig
 from data_safe_haven.config.config_sections import (
@@ -99,20 +100,31 @@ class TestConfig:
             (4, False, False, False, SoftwarePackageCategory.NONE),
         ],
     )
-    def test_template_tiers(self, tier, allow_internet, copy, paste, packages):
+    def test_template_tiers(
+        self,
+        tier: int,
+        allow_internet: bool,
+        copy: bool,
+        paste: bool,
+        packages: SoftwarePackageCategory,
+    ) -> None:
         config = SREConfig.template(tier=tier)
         assert config.sre.allow_workspace_internet == allow_internet
         assert config.sre.remote_desktop.allow_copy == copy
         assert config.sre.remote_desktop.allow_paste == paste
         assert config.sre.software_packages == packages
 
-    def test_from_yaml(self, sre_config, sre_config_yaml) -> None:
+    def test_from_yaml(self, sre_config: SREConfig, sre_config_yaml: str) -> None:
         config = SREConfig.from_yaml(sre_config_yaml)
         assert config == sre_config
         assert isinstance(config.sre.software_packages, SoftwarePackageCategory)
 
     def test_from_remote(
-        self, mocker, context: Context, sre_config: SREConfig, sre_config_yaml: str
+        self,
+        mocker: MockerFixture,
+        context: Context,
+        sre_config: SREConfig,
+        sre_config_yaml: str,
     ) -> None:
         mock_method = mocker.patch.object(
             AzureSdk, "download_blob", return_value=sre_config_yaml
@@ -130,7 +142,9 @@ class TestConfig:
     def test_to_yaml(self, sre_config: SREConfig, sre_config_yaml: str) -> None:
         assert sre_config.to_yaml() == sre_config_yaml
 
-    def test_upload(self, mocker, context, sre_config) -> None:
+    def test_upload(
+        self, mocker: MockerFixture, context: Context, sre_config: SREConfig
+    ) -> None:
         mock_method = mocker.patch.object(AzureSdk, "upload_blob", return_value=None)
         sre_config.upload(context)
 

--- a/tests/config/test_sre_config.py
+++ b/tests/config/test_sre_config.py
@@ -103,9 +103,9 @@ class TestConfig:
     def test_template_tiers(
         self,
         tier: int,
-        allow_internet: bool,
-        copy: bool,
-        paste: bool,
+        allow_internet: bool,  # noqa: FBT001
+        copy: bool,  # noqa: FBT001
+        paste: bool,  # noqa: FBT001
         packages: SoftwarePackageCategory,
     ) -> None:
         config = SREConfig.template(tier=tier)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,6 +633,7 @@ def sre_config_yaml(request: FixtureRequest) -> str:
             home: 100
             shared: 100
             data_disk: 0
+            os_disk: 64
         timezone: Europe/London
         workspace_skus: []
     user_services:


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->
N/A
### :arrow_heading_up: Summary

As part of this PR:
- Users are able to define the size of the OS Disk in the SRE config file. For example, defining a 64GB size OS disk is done with the following:
```yaml
        storage_quota_gb:
            home: 100
            shared: 100
            data_disk: 0
            os_disk: 64
```
- The default OS disk size for workspaces in now 64GB, since the default 30GB have proven to be insufficient.
- We're disabling updating the size of the data disk, since at the moment it triggers the creation of a new VM/Disk, erasing the previously present data.

**IMPORTANT!**: It is not possible to update the OS Disk size using the DSH CLI, due to Pulumi limitations. Attempts of doing it will fail with the following error:

```
Pulumi error:  ~  azure-native:compute:VirtualMachine sre_workspaces_vm_workspace_01 **updating failed** [diff: ~storageProfile];    
error: Status=400 Code="Conflict" Message="Disk resizing is allowed only when creating a VM or when the VM is deallocated."                             
```
We expect users to manually update OS Disk size (using the Portal or Azure CLI), and normalise Pulumi state later.




<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->
Closes: https://github.com/alan-turing-institute/data-safe-haven/issues/2545

### :microscope: Tests

The workspaces are created with the right disk size:

<img width="1444" height="406" alt="image" src="https://github.com/user-attachments/assets/9ff4aa6c-c994-4123-a774-9a310ab741ae" />


<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
