### PR TITLE
Enabling updating TREs from v5.6.0 to v5.7.x

### DIFF
--- a/data_safe_haven/commands/sre.py
+++ b/data_safe_haven/commands/sre.py
@@ -27,6 +27,14 @@ def deploy(
             help="Force this operation, cancelling any others that are in progress.",
         ),
     ] = False,
+    run_program: Annotated[  # noqa: FBT002
+        bool,
+        typer.Option(
+            "--run-program",
+            "-r",
+            help="Run the program during refresh to determine up-to-date state.",
+        ),
+    ] = False,
 ) -> None:
     """Deploy a Secure Research Environment"""
     logger = get_logger()
@@ -161,7 +169,7 @@ def deploy(
 
         # Deploy Azure infrastructure with Pulumi
         try:
-            stack.deploy(force=force)
+            stack.deploy(force=force, run_program=run_program)
         finally:
             # Upload Pulumi config to blob storage
             pulumi_config.upload(context)

--- a/data_safe_haven/commands/sre.py
+++ b/data_safe_haven/commands/sre.py
@@ -35,6 +35,14 @@ def deploy(
             help="Run the program during refresh to determine up-to-date state.",
         ),
     ] = False,
+    disable_diff: Annotated[  # noqa: FBT002
+        bool,
+        typer.Option(
+            "--disable-diff",
+            "-d",
+            help="Remove the rich diff of the overall change during preview.",
+        ),
+    ] = False,
 ) -> None:
     """Deploy a Secure Research Environment"""
     logger = get_logger()
@@ -169,7 +177,7 @@ def deploy(
 
         # Deploy Azure infrastructure with Pulumi
         try:
-            stack.deploy(force=force, run_program=run_program)
+            stack.deploy(force=force, run_program=run_program, disable_diff=disable_diff)
         finally:
             # Upload Pulumi config to blob storage
             pulumi_config.upload(context)

--- a/data_safe_haven/commands/sre.py
+++ b/data_safe_haven/commands/sre.py
@@ -177,7 +177,9 @@ def deploy(
 
         # Deploy Azure infrastructure with Pulumi
         try:
-            stack.deploy(force=force, run_program=run_program, disable_diff=disable_diff)
+            stack.deploy(
+                force=force, run_program=run_program, disable_diff=disable_diff
+            )
         finally:
             # Upload Pulumi config to blob storage
             pulumi_config.upload(context)

--- a/data_safe_haven/infrastructure/components/composite/postgresql_database.py
+++ b/data_safe_haven/infrastructure/components/composite/postgresql_database.py
@@ -54,19 +54,19 @@ class PostgresqlDatabaseComponent(ComponentResource):
             administrator_login=props.database_username,
             administrator_login_password=props.database_password,
             auth_config=dbforpostgresql.AuthConfigArgs(
-                active_directory_auth=dbforpostgresql.ActiveDirectoryAuthEnum.DISABLED,
-                password_auth=dbforpostgresql.PasswordAuthEnum.ENABLED,
+                active_directory_auth=dbforpostgresql.MicrosoftEntraAuth.DISABLED,
+                password_auth=dbforpostgresql.PasswordBasedAuth.ENABLED,
             ),
             backup=dbforpostgresql.BackupArgs(
                 backup_retention_days=7,
-                geo_redundant_backup=dbforpostgresql.GeoRedundantBackupEnum.DISABLED,
+                geo_redundant_backup=dbforpostgresql.GeographicallyRedundantBackup.DISABLED,
             ),
             create_mode=dbforpostgresql.CreateMode.DEFAULT,
             data_encryption=dbforpostgresql.DataEncryptionArgs(
-                type=dbforpostgresql.ArmServerKeyType.SYSTEM_MANAGED,
+                type="SystemManaged",
             ),
             high_availability=dbforpostgresql.HighAvailabilityArgs(
-                mode=dbforpostgresql.HighAvailabilityMode.DISABLED,
+                mode=dbforpostgresql.PostgreSqlFlexibleServerHighAvailabilityMode.DISABLED,
             ),
             location=props.location,
             resource_group_name=props.database_resource_group_name,
@@ -80,7 +80,7 @@ class PostgresqlDatabaseComponent(ComponentResource):
             storage=dbforpostgresql.StorageArgs(
                 storage_size_gb=32,
             ),
-            version=dbforpostgresql.ServerVersion.SERVER_VERSION_14,
+            version=dbforpostgresql.PostgresMajorVersion.POSTGRES_MAJOR_VERSION_14,
             opts=child_opts,
             tags=child_tags,
         )

--- a/data_safe_haven/infrastructure/programs/declarative_sre.py
+++ b/data_safe_haven/infrastructure/programs/declarative_sre.py
@@ -29,7 +29,7 @@ from .sre.entra import SREEntraComponent, SREEntraProps
 from .sre.firewall import SREFirewallComponent, SREFirewallProps
 from .sre.identity import SREIdentityComponent, SREIdentityProps
 from .sre.monitoring import (
-    SREMonitoringNetworkingComponent,
+    SREMonitoringComponent,
     SREMonitoringNetworkingProps,
 )
 from .sre.monitoring_elements import (
@@ -201,7 +201,7 @@ class DeclarativeSRE:
         )
 
         # Deploy monitoring networking
-        SREMonitoringNetworkingComponent(
+        SREMonitoringComponent(
             "sre_monitoring",
             self.stack_name,
             SREMonitoringNetworkingProps(

--- a/data_safe_haven/infrastructure/programs/sre/dns_sidecar.py
+++ b/data_safe_haven/infrastructure/programs/sre/dns_sidecar.py
@@ -158,7 +158,9 @@ class DnsSidecarComponent(ComponentResource):
                     ResourceOptions(
                         depends_on=[container_instance.local_dns.public_dns_record_set],
                         delete_before_replace=True,
-                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dns_updater_role"]
+                        aliases=[
+                            f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dns_updater_role"
+                        ],
                     ),
                 ),
             )
@@ -179,7 +181,9 @@ class DnsSidecarComponent(ComponentResource):
                     ResourceOptions(
                         depends_on=[dns_zone_role_definition],
                         delete_before_replace=True,
-                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_dns_updater_job_role_assignment"]
+                        aliases=[
+                            f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_dns_updater_job_role_assignment"
+                        ],
                     ),
                 ),
             )
@@ -204,7 +208,9 @@ class DnsSidecarComponent(ComponentResource):
                     ResourceOptions(
                         depends_on=[container_instance.container_group],
                         delete_before_replace=True,
-                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_role"]
+                        aliases=[
+                            f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_role"
+                        ],
                     ),
                 ),
             )
@@ -225,8 +231,9 @@ class DnsSidecarComponent(ComponentResource):
                     ResourceOptions(
                         depends_on=[container_group_role_definition],
                         delete_before_replace=True,
-                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_job_role_assignment"]
-
+                        aliases=[
+                            f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_job_role_assignment"
+                        ],
                     ),
                 ),
             )

--- a/data_safe_haven/infrastructure/programs/sre/dns_sidecar.py
+++ b/data_safe_haven/infrastructure/programs/sre/dns_sidecar.py
@@ -139,8 +139,8 @@ class DnsSidecarComponent(ComponentResource):
 
             # Allowing the managed identity to update DNS Records
             dns_zone_role_definition = authorization.RoleDefinition(
-                f"{self._name}_{container_instance.dns_record_name}_dns_updater_role",
-                role_name=f"DNS Zone updater for {container_instance.dns_record_name} ({stack_name})",
+                f"{stack_name}_{container_instance.dns_record_name}_dns_updater_role",
+                role_name=f"DNS Zone updater: {container_instance.dns_record_name} ({stack_name})",
                 scope=container_instance.local_dns.private_record_set_id,
                 description=f"Role for updating {container_instance.dns_record_name}'s DNS records",
                 permissions=[
@@ -157,13 +157,14 @@ class DnsSidecarComponent(ComponentResource):
                     child_opts,
                     ResourceOptions(
                         depends_on=[container_instance.local_dns.public_dns_record_set],
-                        parent=user_assigned_identity,
+                        delete_before_replace=True,
+                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dns_updater_role"]
                     ),
                 ),
             )
 
             self.dns_zone_role_assignment = authorization.RoleAssignment(
-                f"{self._name}_{container_instance.dns_record_name}_dnssidecar_dns_updater_job_role_assignment",
+                f"{stack_name}_{container_instance.dns_record_name}_dnssidecar_dns_updater_job_role_assignment",
                 principal_id=user_assigned_identity.principal_id,
                 principal_type=authorization.PrincipalType.SERVICE_PRINCIPAL,
                 role_assignment_name=str(
@@ -177,15 +178,16 @@ class DnsSidecarComponent(ComponentResource):
                     child_opts,
                     ResourceOptions(
                         depends_on=[dns_zone_role_definition],
-                        parent=user_assigned_identity,
+                        delete_before_replace=True,
+                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_dns_updater_job_role_assignment"]
                     ),
                 ),
             )
 
             # Allow the managed identity to retrieve the container group IP
             container_group_role_definition = authorization.RoleDefinition(
-                f"{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_role",
-                role_name=f"Container group reader for {container_instance.dns_record_name} ({stack_name})",
+                f"{stack_name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_role",
+                role_name=f"Container group reader: {container_instance.dns_record_name} ({stack_name})",
                 scope=container_instance.container_group.id,
                 description=f"Role for reading {container_instance.dns_record_name}'s container group",
                 permissions=[
@@ -201,13 +203,14 @@ class DnsSidecarComponent(ComponentResource):
                     child_opts,
                     ResourceOptions(
                         depends_on=[container_instance.container_group],
-                        parent=user_assigned_identity,
+                        delete_before_replace=True,
+                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::azure-native:authorization:RoleDefinition::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_role"]
                     ),
                 ),
             )
 
             self.container_group_role_assignment = authorization.RoleAssignment(
-                f"{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_job_role_assignment",
+                f"{stack_name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_job_role_assignment",
                 principal_id=user_assigned_identity.principal_id,
                 principal_type=authorization.PrincipalType.SERVICE_PRINCIPAL,
                 role_assignment_name=str(
@@ -221,7 +224,9 @@ class DnsSidecarComponent(ComponentResource):
                     child_opts,
                     ResourceOptions(
                         depends_on=[container_group_role_definition],
-                        parent=user_assigned_identity,
+                        delete_before_replace=True,
+                        aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:DnsSidecarComponent$azure-native:authorization:RoleAssignment::{self._name}_{container_instance.dns_record_name}_dnssidecar_ip_reader_job_role_assignment"]
+
                     ),
                 ),
             )

--- a/data_safe_haven/infrastructure/programs/sre/monitoring.py
+++ b/data_safe_haven/infrastructure/programs/sre/monitoring.py
@@ -32,7 +32,7 @@ class SREMonitoringNetworkingProps:
         self.timezone = timezone
 
 
-class SREMonitoringNetworkingComponent(ComponentResource):
+class SREMonitoringComponent(ComponentResource):
     """Deploy SRE monitoring with Pulumi"""
 
     def __init__(

--- a/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
+++ b/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
@@ -65,7 +65,7 @@ class SREMonitoringElementsComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(
-                    aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:maintenance:MaintenanceConfiguration::sre_monitoring_maintenance_configuration"],
+                    aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:maintenance:MaintenanceConfiguration::sre_monitoring_maintenance_configuration"],
                     # Ignore start_date_time or this will be changed on each redeploy
                     ignore_changes=["start_date_time"],
                 ),
@@ -86,7 +86,7 @@ class SREMonitoringElementsComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(aliases=[
-                    "urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace::sre_monitoring_log_analytics"
+                    f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace::sre_monitoring_log_analytics"
                 ]),
             ),
             tags=child_tags,
@@ -104,7 +104,7 @@ class SREMonitoringElementsComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(parent=self.log_analytics,
-                                aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionEndpoint::sre_monitoring_data_collection_endpoint"]),
+                                aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionEndpoint::sre_monitoring_data_collection_endpoint"]),
             ),
             tags=child_tags,
         )
@@ -199,7 +199,7 @@ class SREMonitoringElementsComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(parent=self.log_analytics, aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionRule::sre_monitoring_data_collection_rule_vms"]),
+                ResourceOptions(parent=self.log_analytics, aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionRule::sre_monitoring_data_collection_rule_vms"]),
             ),
             tags=child_tags,
         )

--- a/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
+++ b/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
@@ -65,7 +65,9 @@ class SREMonitoringElementsComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(
-                    aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:maintenance:MaintenanceConfiguration::sre_monitoring_maintenance_configuration"],
+                    aliases=[
+                        f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:maintenance:MaintenanceConfiguration::sre_monitoring_maintenance_configuration"
+                    ],
                     # Ignore start_date_time or this will be changed on each redeploy
                     ignore_changes=["start_date_time"],
                 ),
@@ -85,9 +87,11 @@ class SREMonitoringElementsComponent(ComponentResource):
             workspace_name=f"{stack_name}-log",
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(aliases=[
-                    f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace::sre_monitoring_log_analytics"
-                ]),
+                ResourceOptions(
+                    aliases=[
+                        f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace::sre_monitoring_log_analytics"
+                    ]
+                ),
             ),
             tags=child_tags,
         )
@@ -103,8 +107,12 @@ class SREMonitoringElementsComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(parent=self.log_analytics,
-                                aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionEndpoint::sre_monitoring_data_collection_endpoint"]),
+                ResourceOptions(
+                    parent=self.log_analytics,
+                    aliases=[
+                        f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionEndpoint::sre_monitoring_data_collection_endpoint"
+                    ],
+                ),
             ),
             tags=child_tags,
         )
@@ -199,7 +207,12 @@ class SREMonitoringElementsComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(parent=self.log_analytics, aliases=[f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionRule::sre_monitoring_data_collection_rule_vms"]),
+                ResourceOptions(
+                    parent=self.log_analytics,
+                    aliases=[
+                        f"urn:pulumi:{stack_name}::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionRule::sre_monitoring_data_collection_rule_vms"
+                    ],
+                ),
             ),
             tags=child_tags,
         )

--- a/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
+++ b/data_safe_haven/infrastructure/programs/sre/monitoring_elements.py
@@ -31,7 +31,7 @@ class SREMonitoringElementsComponent(ComponentResource):
         opts: ResourceOptions | None = None,
         tags: Input[Mapping[str, Input[str]]] | None = None,
     ):
-        super().__init__("dsh:sre:BasicMonitoringComponent", name, {}, opts)
+        super().__init__("dsh:sre:MonitoringElementsComponent", name, {}, opts)
         child_opts = ResourceOptions.merge(opts, ResourceOptions(parent=self))
         child_tags = {"component": "monitoring"} | (tags if tags else {})
 
@@ -65,8 +65,9 @@ class SREMonitoringElementsComponent(ComponentResource):
             opts=ResourceOptions.merge(
                 child_opts,
                 ResourceOptions(
+                    aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:maintenance:MaintenanceConfiguration::sre_monitoring_maintenance_configuration"],
                     # Ignore start_date_time or this will be changed on each redeploy
-                    ignore_changes=["start_date_time"]
+                    ignore_changes=["start_date_time"],
                 ),
             ),
             tags=child_tags,
@@ -82,7 +83,12 @@ class SREMonitoringElementsComponent(ComponentResource):
                 name=operationalinsights.WorkspaceSkuNameEnum.PER_GB2018,
             ),
             workspace_name=f"{stack_name}-log",
-            opts=child_opts,
+            opts=ResourceOptions.merge(
+                child_opts,
+                ResourceOptions(aliases=[
+                    "urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace::sre_monitoring_log_analytics"
+                ]),
+            ),
             tags=child_tags,
         )
 
@@ -97,7 +103,8 @@ class SREMonitoringElementsComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(parent=self.log_analytics),
+                ResourceOptions(parent=self.log_analytics,
+                                aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionEndpoint::sre_monitoring_data_collection_endpoint"]),
             ),
             tags=child_tags,
         )
@@ -192,7 +199,7 @@ class SREMonitoringElementsComponent(ComponentResource):
             resource_group_name=props.resource_group_name,
             opts=ResourceOptions.merge(
                 child_opts,
-                ResourceOptions(parent=self.log_analytics),
+                ResourceOptions(parent=self.log_analytics, aliases=["urn:pulumi:shm-cvdnetdev-sre-arg::data-safe-haven::dsh:sre:MonitoringComponent$azure-native:operationalinsights:Workspace$azure-native:monitor:DataCollectionRule::sre_monitoring_data_collection_rule_vms"]),
             ),
             tags=child_tags,
         )

--- a/data_safe_haven/infrastructure/programs/sre/networking.py
+++ b/data_safe_haven/infrastructure/programs/sre/networking.py
@@ -1955,9 +1955,7 @@ class SRENetworkingComponent(ComponentResource):
                 virtual_network_name=sre_virtual_network.name,
             )
 
-            self.subnet_user_services_software_repositories_support: (
-                Output[network.Subnet] | None
-            ) = sre_virtual_network.subnets.apply(
+            self.subnet_user_services_software_repositories_support = sre_virtual_network.subnets.apply(
                 lambda subnets: next(
                     filter(
                         lambda subnet: subnet.name

--- a/data_safe_haven/infrastructure/programs/sre/networking.py
+++ b/data_safe_haven/infrastructure/programs/sre/networking.py
@@ -1,6 +1,6 @@
 """Pulumi component for SRE networking"""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 from pulumi import ComponentResource, Input, InvokeOptions, Output, ResourceOptions
 from pulumi_azure_native import dns, network, privatedns, provider
@@ -1955,14 +1955,12 @@ class SRENetworkingComponent(ComponentResource):
                 virtual_network_name=sre_virtual_network.name,
             )
 
-            self.subnet_user_services_software_repositories_support = sre_virtual_network.subnets.apply(
-                lambda subnets: next(
-                    filter(
-                        lambda subnet: subnet.name
-                        == self.subnet_user_services_software_repositories_support_name,
+            self.subnet_user_services_software_repositories_support = (
+                sre_virtual_network.subnets.apply(
+                    lambda subnets: self.get_subnet_by_name(
+                        self.subnet_user_services_software_repositories_support_name,
                         subnets,
-                    ),
-                    None,
+                    )
                 )
             )
 
@@ -1979,6 +1977,19 @@ class SRENetworkingComponent(ComponentResource):
             virtual_network_name=sre_virtual_network.name,
         )
         self.virtual_network = sre_virtual_network
+
+    @staticmethod
+    def get_subnet_by_name(
+        subnet_name: str,
+        subnets: Output[Sequence[network.Subnet]],
+    ) -> Output[network.Subnet]:
+        return next(
+            filter(
+                lambda subnet: subnet.name == subnet_name,
+                subnets,
+            ),
+            None,
+        )
 
     def get_nsg_user_services_gitea_mirror(
         self,

--- a/data_safe_haven/infrastructure/programs/sre/networking.py
+++ b/data_safe_haven/infrastructure/programs/sre/networking.py
@@ -1941,7 +1941,7 @@ class SRENetworkingComponent(ComponentResource):
             Output[network.GetSubnetResult] | None
         ) = None
         self.subnet_user_services_software_repositories_support: (
-            Output[network.GetSubnetResult] | None
+            Output[network.Subnet] | None
         ) = None
 
         self.subnet_user_services_gitea_mirror: (
@@ -1955,10 +1955,17 @@ class SRENetworkingComponent(ComponentResource):
                 virtual_network_name=sre_virtual_network.name,
             )
 
-            self.subnet_user_services_software_repositories_support = network.get_subnet_output(
-                subnet_name=self.subnet_user_services_software_repositories_support_name,
-                resource_group_name=props.resource_group_name,
-                virtual_network_name=sre_virtual_network.name,
+            self.subnet_user_services_software_repositories_support: (
+                Output[network.Subnet] | None
+            ) = sre_virtual_network.subnets.apply(
+                lambda subnets: next(
+                    filter(
+                        lambda subnet: subnet.name
+                        == self.subnet_user_services_software_repositories_support_name,
+                        subnets,
+                    ),
+                    None,
+                )
             )
 
         if props.use_gitea_mirror:

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -206,7 +206,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                         database_password=props.database_password,
                         database_resource_group_name=props.resource_group_name,
                         database_server_name=f"{stack_name}-db-server-software-repositories",
-                        database_subnet_id= Output.from_input(
+                        database_subnet_id=Output.from_input(
                             props.subnet_software_repositories_support
                         ).apply(get_id_from_subnet),
                         database_username=props.database_username,
@@ -409,7 +409,10 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                     ResourceOptions(
                         delete_before_replace=True,
                         replace_on_changes=["containers"],
-                        depends_on=[props.log_analytics_workspace, db_server_software_repositories],
+                        depends_on=[
+                            props.log_analytics_workspace,
+                            db_server_software_repositories,
+                        ],
                     ),
                 ),
                 tags=child_tags,

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -9,7 +9,6 @@ from pulumi_azure_native import containerinstance, network, operationalinsights,
 from data_safe_haven.external import AzureIPv4Range
 from data_safe_haven.infrastructure.common import (
     DockerHubCredentials,
-    get_id_from_subnet,
     get_ip_address_from_container_group,
 )
 from data_safe_haven.infrastructure.components import (
@@ -48,7 +47,7 @@ class SRESoftwareRepositoriesProps:
         storage_account_key: Input[str],
         storage_account_name: Input[str],
         subnet_software_repositories_id: Input[str],
-        subnet_software_repositories_support: Input[network.GetSubnetResult],
+        subnet_software_repositories_support: Input[network.Subnet] | None,
         database_username: Input[str] | None = "postgresadmin",
     ) -> None:
         self.database_password = database_password
@@ -72,18 +71,14 @@ class SRESoftwareRepositoriesProps:
         self.storage_account_name = storage_account_name
         self.subnet_software_repositories_id = subnet_software_repositories_id
         self.subnet_software_repositories_support = subnet_software_repositories_support
-        self.subnet_software_repositories_support_ip_addresses = Output.from_input(
-            subnet_software_repositories_support
-        ).apply(
-            lambda s: (
-                [
-                    str(ip)
-                    for ip in AzureIPv4Range.from_cidr(s.address_prefix).available()
-                ]
-                if s.address_prefix
-                else []
-            )
+
+def obtain_first_ip_address(address_prefix: str) -> str | None:
+    if address_prefix:
+        return next(
+            str(ip) for ip in AzureIPv4Range.from_cidr(address_prefix).available()
         )
+
+    return None
 
 
 class SRESoftwareRepositoriesComponent(ComponentResource):
@@ -193,30 +188,13 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
         self.container_group: containerinstance.ContainerGroup | None = None
         self.exports: dict[str, Any] | None = None
 
-        if props.nexus_packages:
 
-            # Define a PostgreSQL server for Nexus
-            db_software_repository_name: str = "nexus"
-            db_server_software_repositories: PostgresqlDatabaseComponent = (
-                PostgresqlDatabaseComponent(
-                    f"{self._name}_db_nexus",
-                    PostgresqlDatabaseProps(
-                        azure_extensions=PostgreSqlExtension.PG_TRGM,  # Extension required by Nexus.
-                        database_names=[db_software_repository_name],
-                        database_password=props.database_password,
-                        database_resource_group_name=props.resource_group_name,
-                        database_server_name=f"{stack_name}-db-server-software-repositories",
-                        database_subnet_id=Output.from_input(
-                            props.subnet_software_repositories_support
-                        ).apply(get_id_from_subnet),
-                        database_username=props.database_username,
-                        disable_secure_transport=False,
-                        location=props.location,
-                    ),
-                    opts=child_opts,
-                    tags=child_tags,
-                )
-            )
+        if (
+            props.nexus_packages
+            and props.subnet_software_repositories_support is not None
+            and hasattr(props.subnet_software_repositories_support, "id")
+            and hasattr(props.subnet_software_repositories_support, "address_prefix")
+        ):
 
             # Define the container group with nexus and caddy
             self.dns_record_name = "nexus"
@@ -251,18 +229,13 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                         ],
                     ),
                     containerinstance.ContainerArgs(
-                        image="sonatype/nexus3:3.88.0",
+                        image="sonatype/nexus3:3.87.1",  # Version 3.38.0 currently fails deployment. Keeping previous version.
                         name="nexus"[:63],
                         environment_variables=[
                             containerinstance.EnvironmentVariableArgs(
                                 name="NEXUS_DATASTORE_NEXUS_JDBCURL",
-                                value=Output.concat(
-                                    "jdbc:postgresql://",
-                                    props.subnet_software_repositories_support_ip_addresses[
-                                        0
-                                    ],
-                                    ":5432/nexus?",
-                                    "gssEncMode=disable&tcpKeepAlive=true&loginTimeout=5&connectionTimeout=5&socketTimeout=30&cancelSignalTimeout=5&targetServerType=primary",
+                                value=props.subnet_software_repositories_support.address_prefix.apply(
+                                    lambda address_prefix: f"jdbc:postgresql://{obtain_first_ip_address(address_prefix)}:5432/nexus?gssEncMode=disable&tcpKeepAlive=true&loginTimeout=5&connectionTimeout=5&socketTimeout=30&cancelSignalTimeout=5&targetServerType=primary",
                                 ),
                             ),
                             containerinstance.EnvironmentVariableArgs(
@@ -411,11 +384,36 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                         replace_on_changes=["containers"],
                         depends_on=[
                             props.log_analytics_workspace,
-                            db_server_software_repositories,
                         ],
                     ),
                 ),
                 tags=child_tags,
+            )
+
+            # Define a PostgreSQL server for Nexus
+            db_software_repository_name: str = "nexus"
+            db_server_software_repositories: PostgresqlDatabaseComponent = (
+                PostgresqlDatabaseComponent(
+                    f"{self._name}_db_nexus",
+                    PostgresqlDatabaseProps(
+                        azure_extensions=PostgreSqlExtension.PG_TRGM,  # Extension required by Nexus.
+                        database_names=[db_software_repository_name],
+                        database_password=props.database_password,
+                        database_resource_group_name=props.resource_group_name,
+                        database_server_name=f"{stack_name}-db-server-software-repositories",
+                        database_subnet_id=props.subnet_software_repositories_support.id,
+                        database_username=props.database_username,
+                        disable_secure_transport=False,
+                        location=props.location,
+                    ),
+                    opts=ResourceOptions.merge(
+                        child_opts,
+                        ResourceOptions(
+                            replace_with=[self.container_group]
+                        ),
+                    ),
+                    tags=child_tags,
+                )
             )
 
             # Register the container group in the SRE DNS zone

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -73,15 +73,6 @@ class SRESoftwareRepositoriesProps:
         self.subnet_software_repositories_support = subnet_software_repositories_support
 
 
-def obtain_first_ip_address(address_prefix: str) -> str | None:
-    if address_prefix:
-        return next(
-            str(ip) for ip in AzureIPv4Range.from_cidr(address_prefix).available()
-        )
-
-    return None
-
-
 class SRESoftwareRepositoriesComponent(ComponentResource):
     """Deploy SRE update servers with Pulumi"""
 
@@ -192,8 +183,6 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
         if (
             props.nexus_packages
             and props.subnet_software_repositories_support is not None
-            and hasattr(props.subnet_software_repositories_support, "id")
-            and hasattr(props.subnet_software_repositories_support, "address_prefix")
         ):
 
             # Define the container group with nexus and caddy
@@ -235,7 +224,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                             containerinstance.EnvironmentVariableArgs(
                                 name="NEXUS_DATASTORE_NEXUS_JDBCURL",
                                 value=props.subnet_software_repositories_support.address_prefix.apply(
-                                    lambda address_prefix: f"jdbc:postgresql://{obtain_first_ip_address(address_prefix)}:5432/nexus?gssEncMode=disable&tcpKeepAlive=true&loginTimeout=5&connectionTimeout=5&socketTimeout=30&cancelSignalTimeout=5&targetServerType=primary",
+                                    lambda address_prefix: f"jdbc:postgresql://{self.obtain_first_ip_address(address_prefix)}:5432/nexus?gssEncMode=disable&tcpKeepAlive=true&loginTimeout=5&connectionTimeout=5&socketTimeout=30&cancelSignalTimeout=5&targetServerType=primary",
                                 ),
                             ),
                             containerinstance.EnvironmentVariableArgs(
@@ -447,3 +436,12 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
             "cran": cran_allowlist.destination_path,
             "pypi": pypi_allowlist.destination_path,
         }
+
+    @staticmethod
+    def obtain_first_ip_address(address_prefix: str | None) -> str | None:
+        if address_prefix:
+            return next(
+                str(ip) for ip in AzureIPv4Range.from_cidr(address_prefix).available()
+            )
+
+        return None

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -72,6 +72,7 @@ class SRESoftwareRepositoriesProps:
         self.subnet_software_repositories_id = subnet_software_repositories_id
         self.subnet_software_repositories_support = subnet_software_repositories_support
 
+
 def obtain_first_ip_address(address_prefix: str) -> str | None:
     if address_prefix:
         return next(
@@ -187,7 +188,6 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
 
         self.container_group: containerinstance.ContainerGroup | None = None
         self.exports: dict[str, Any] | None = None
-
 
         if (
             props.nexus_packages
@@ -408,9 +408,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                     ),
                     opts=ResourceOptions.merge(
                         child_opts,
-                        ResourceOptions(
-                            replace_with=[self.container_group]
-                        ),
+                        ResourceOptions(replace_with=[self.container_group]),
                     ),
                     tags=child_tags,
                 )

--- a/data_safe_haven/infrastructure/programs/sre/software_repositories.py
+++ b/data_safe_haven/infrastructure/programs/sre/software_repositories.py
@@ -71,9 +71,7 @@ class SRESoftwareRepositoriesProps:
         self.storage_account_key = storage_account_key
         self.storage_account_name = storage_account_name
         self.subnet_software_repositories_id = subnet_software_repositories_id
-        self.subnet_software_repositories_support_id = Output.from_input(
-            subnet_software_repositories_support
-        ).apply(get_id_from_subnet)
+        self.subnet_software_repositories_support = subnet_software_repositories_support
         self.subnet_software_repositories_support_ip_addresses = Output.from_input(
             subnet_software_repositories_support
         ).apply(
@@ -208,7 +206,9 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                         database_password=props.database_password,
                         database_resource_group_name=props.resource_group_name,
                         database_server_name=f"{stack_name}-db-server-software-repositories",
-                        database_subnet_id=props.subnet_software_repositories_support_id,
+                        database_subnet_id= Output.from_input(
+                            props.subnet_software_repositories_support
+                        ).apply(get_id_from_subnet),
                         database_username=props.database_username,
                         disable_secure_transport=False,
                         location=props.location,
@@ -409,7 +409,7 @@ class SRESoftwareRepositoriesComponent(ComponentResource):
                     ResourceOptions(
                         delete_before_replace=True,
                         replace_on_changes=["containers"],
-                        depends_on=[props.log_analytics_workspace],
+                        depends_on=[props.log_analytics_workspace, db_server_software_repositories],
                     ),
                 ),
                 tags=child_tags,

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -242,14 +242,20 @@ class ProjectManager:
             msg = "Pulumi destroy failed."
             raise DataSafeHavenPulumiError(msg) from exc
 
-    def deploy(self, *, force: bool = False, run_program: bool = False) -> None:
+    def deploy(
+        self,
+        *,
+        force: bool = False,
+        run_program: bool = False,
+        disable_diff: bool = False,
+    ) -> None:
         """Deploy the infrastructure with Pulumi."""
         try:
             self.apply_config_options()
             if force:
                 self.cancel()
             self.refresh(run_program)
-            self.preview()
+            self.preview(disable_diff)
             self.update()
         except Exception as exc:
             msg = "Pulumi deployment failed."
@@ -340,7 +346,7 @@ class ProjectManager:
             self._stack_outputs = self.stack.outputs()
         return self._stack_outputs[name].value
 
-    def preview(self) -> None:
+    def preview(self, disable_diff: bool = False) -> None:  # noqa: FBT001, FBT002
         """Preview the Pulumi stack."""
         try:
             self.logger.info(
@@ -349,7 +355,7 @@ class ProjectManager:
             with suppress(automation.CommandError):
                 # Note that we disable parallelisation which can cause deadlock
                 self.stack.preview(
-                    diff=True,
+                    diff=not disable_diff,
                     parallel=1,
                     **self.pulumi_extra_args,
                 )
@@ -360,7 +366,9 @@ class ProjectManager:
     def refresh(self, run_program: bool = False) -> None:  # noqa: FBT001, FBT002
         """Refresh the Pulumi stack."""
         try:
-            self.logger.info(f"Refreshing stack [green]{self.stack.name}[/].")
+            self.logger.info(
+                f"Refreshing stack [green]{self.stack.name}[/] with --run-program={run_program}"
+            )
             # Note that we disable parallelisation which can cause deadlock
             self.stack.refresh(
                 parallel=1, run_program=run_program, **self.pulumi_extra_args

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -357,7 +357,7 @@ class ProjectManager:
             msg = "Pulumi preview failed.."
             raise DataSafeHavenPulumiError(msg) from exc
 
-    def refresh(self, run_program: bool) -> None:  # noqa: FBT001
+    def refresh(self, run_program: bool = False) -> None:  # noqa: FBT001, FBT002
         """Refresh the Pulumi stack."""
         try:
             self.logger.info(f"Refreshing stack [green]{self.stack.name}[/].")

--- a/data_safe_haven/infrastructure/project_manager.py
+++ b/data_safe_haven/infrastructure/project_manager.py
@@ -242,13 +242,13 @@ class ProjectManager:
             msg = "Pulumi destroy failed."
             raise DataSafeHavenPulumiError(msg) from exc
 
-    def deploy(self, *, force: bool = False) -> None:
+    def deploy(self, *, force: bool = False, run_program: bool = False) -> None:
         """Deploy the infrastructure with Pulumi."""
         try:
             self.apply_config_options()
             if force:
                 self.cancel()
-            self.refresh()
+            self.refresh(run_program)
             self.preview()
             self.update()
         except Exception as exc:
@@ -357,12 +357,15 @@ class ProjectManager:
             msg = "Pulumi preview failed.."
             raise DataSafeHavenPulumiError(msg) from exc
 
-    def refresh(self) -> None:
+    def refresh(self, run_program: bool) -> None:  # noqa: FBT001
         """Refresh the Pulumi stack."""
         try:
             self.logger.info(f"Refreshing stack [green]{self.stack.name}[/].")
             # Note that we disable parallelisation which can cause deadlock
-            self.stack.refresh(parallel=1, **self.pulumi_extra_args)
+            self.stack.refresh(
+                parallel=1, run_program=run_program, **self.pulumi_extra_args
+            )
+
         except automation.CommandError as exc:
             self.log_exception(exc)
             msg = "Pulumi refresh failed."


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A

### :arrow_heading_up: Summary

As part of this PR:

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->
- PR https://github.com/alan-turing-institute/data-safe-haven/pull/2548 broke the `PostgresqlDatabaseComponent` component by changing the types of some Enums. We fixed this (see: `postgresql_database.py`)
- PR https://github.com/alan-turing-institute/data-safe-haven/pull/2500/changes made a refactoring of the monitoring component, that produced changes in the object IDs. By using [aliases](https://www.pulumi.com/docs/iac/concepts/resources/#aliases), we're able to link the refactored objects with their original ID (see: `monitoring_elements.py`).
- Updating to v5.7.0 caused multiple errors in the DNS Sidecar roles and role assignments due to name collisions. By making roles and resource names more precise (by including the stack name) and using aliases, the errors disappear (see `dns_sidecar.py`).

**IMPORTANT!:** As part of the update process, we still need to manually remove the DNS Server container instance, that was replaced by PR https://github.com/alan-turing-institute/data-safe-haven/pull/2500/changes 

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

We deployed a `v5.6.0` TRE and successfully updated to `v5.7.0`.
