### PR TITLE
Ensure dshadmin home directory exists

### DIFF
--- a/data_safe_haven/resources/workspace/ansible/desired_state.yaml
+++ b/data_safe_haven/resources/workspace/ansible/desired_state.yaml
@@ -26,6 +26,10 @@
       ansible.builtin.import_tasks: tasks/clamav.yaml
       tags: clamav
 
+    - name: Configure admin account
+      ansible.builtin.import_tasks: tasks/admin_config.yaml
+      tags: admin_conf
+
     - name: Globally configure default user settings
       ansible.builtin.import_tasks: tasks/user_config.yaml
       tags: user_conf

--- a/data_safe_haven/resources/workspace/ansible/tasks/admin_config.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/admin_config.yaml
@@ -1,0 +1,10 @@
+---
+
+- name: Create home directory
+  ansible.builtin.file:
+    path: /home/dshadmin
+    state: directory
+    owner: dshadmin
+    group: dshadmin
+    mode: '0700'
+    recurse: false

--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -21,7 +21,7 @@ Deploying an instance of the Data Safe Haven involves the following steps:
 
 Install the following requirements before starting
 
-- [Python 3.12](https://wiki.python.org/moin/BeginnersGuide/Download)
+- [Python 3.12](https://docs.python.org/3.12/using/index.html)
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [pipx](https://pipx.pypa.io/stable/installation/)
 - [Pulumi](https://www.pulumi.com/docs/iac/get-started/azure/)


### PR DESCRIPTION
Ensures appropriate ownership and permissions

## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

The `dshadmin` home directory isn't created until the user logs in. If we use the serial console the directory is created with ownership `root:root` and so dshadmin is unable to write files. This is possibly because it bypasses `pam_mkhomedir`. In any case, it felt easier to make the directory and it's permissions part of the regular desired state.


### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
