### PR TITLE
Fix ansible error due to apt cache update before key imported

### DIFF
--- a/data_safe_haven/provisioning/sre_provisioning_manager.py
+++ b/data_safe_haven/provisioning/sre_provisioning_manager.py
@@ -107,9 +107,7 @@ class SREProvisioningManager:
     def initialise_software_repository_database(self) -> None:
         """Configures a PostgreSQL database for the Nexus container"""
         if self.software_repository_params:
-            self.logger.info(
-                "Configuring software repository database."
-            )
+            self.logger.info("Configuring software repository database.")
 
             postgres_provisioner = AzurePostgreSQLDatabase(
                 self.software_repository_params["connection_db_name"],
@@ -140,9 +138,7 @@ class SREProvisioningManager:
 
     def update_remote_desktop_connections(self) -> None:
         """Update connection information on the Guacamole PostgreSQL server"""
-        self.logger.info(
-            "Configuring remote desktop connections database."
-        )
+        self.logger.info("Configuring remote desktop connections database.")
         postgres_provisioner = AzurePostgreSQLDatabase(
             self.remote_desktop_params["connection_db_name"],
             self.remote_desktop_params["connection_db_server_password"],

--- a/data_safe_haven/provisioning/sre_provisioning_manager.py
+++ b/data_safe_haven/provisioning/sre_provisioning_manager.py
@@ -108,7 +108,7 @@ class SREProvisioningManager:
         """Configures a PostgreSQL database for the Nexus container"""
         if self.software_repository_params:
             self.logger.info(
-                "Setting up a PostgreSQL database for the Nexus repository..."
+                "Configuring software repository database."
             )
 
             postgres_provisioner = AzurePostgreSQLDatabase(
@@ -140,6 +140,9 @@ class SREProvisioningManager:
 
     def update_remote_desktop_connections(self) -> None:
         """Update connection information on the Guacamole PostgreSQL server"""
+        self.logger.info(
+            "Configuring remote desktop connections database."
+        )
         postgres_provisioner = AzurePostgreSQLDatabase(
             self.remote_desktop_params["connection_db_name"],
             self.remote_desktop_params["connection_db_server_password"],

--- a/data_safe_haven/resources/workspace/ansible/host_vars/localhost.yaml
+++ b/data_safe_haven/resources/workspace/ansible/host_vars/localhost.yaml
@@ -24,7 +24,7 @@ package_categories:
   - category: database
     common:
       - libpq-dev     # interact with PostgreSQL databases
-      - msodbcsql17   # interact with Microsoft SQL databases
+      - msodbcsql18   # interact with Microsoft SQL databases
       - postgresql-client  # CLI psql client
       - unixodbc-dev  # interact with Microsoft SQL databases
     jammy: []
@@ -37,8 +37,8 @@ package_categories:
       - clojure  # Clojure functional programming language for JVM
       - cmake  # CMake build system
       - default-jre  # Java runtime environment
-      - dotnet-runtime  # .Net runtime
-      - dotnet-sdk  # .Net SDK
+      - dotnet-runtime-9.0  # .Net runtime
+      - dotnet-sdk-9.0  # .Net SDK
       - fsharp  # F# functional-first programming language
       - g++  # GNU C++ compiler
       - gcc  # GNU C compiler

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -3,16 +3,17 @@
 - name: Microsoft packages repo
   tags: apt
   block:
+    - name: Import Microsoft package signing key
+      ansible.builtin.apt_key:
+        keyserver: keyserver.ubuntu.com
+        id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
+
     - name: Add Microsoft packages source
       ansible.builtin.apt_repository:
         repo: "deb https://packages.microsoft.com/ubuntu/{{ ansible_facts.distribution_version }}/prod {{ ansible_facts.distribution_release }} main"
         state: present
         filename: microsoft-general
-
-    - name: Import key
-      ansible.builtin.apt_key:
-        keyserver: keyserver.ubuntu.com
-        id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
+        update_cache: false
 
 - name: Apt packages
   tags: apt

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -28,7 +28,7 @@
       ansible.builtin.template:
         src: etc/apt/preferences.d/microsoft-general.j2
         dest: /etc/apt/preferences.d/microsoft-general
-        mode: 644
+        mode: "0644"
 
 - name: Apt packages
   tags: apt

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -3,11 +3,16 @@
 - name: Microsoft packages repo
   tags: apt
   block:
-    - name: Fetch Microsoft package signing key
-      ansible.builtin.get_url:
-        url: https://packages.microsoft.com/keys/microsoft.asc
-        dest: /etc/apt/keyrings/microsoft.asc
-        checksum: sha256:2fa9c05d591a1582a9aba276272478c262e95ad00acf60eaee1644d93941e3c6
+    # This should be the preferred method, but the Ubuntu image has old Curl/OpenSSL
+    # - name: Fetch Microsoft package signing key
+    #   ansible.builtin.get_url:
+    #     url: https://packages.microsoft.com/keys/microsoft.asc
+    #     dest: /etc/apt/keyrings/microsoft.asc
+    #     checksum: sha256:2fa9c05d591a1582a9aba276272478c262e95ad00acf60eaee1644d93941e3c6
+    - name: Import Microsoft package signing key
+      ansible.builtin.apt_key:
+        keyserver: keyserver.ubuntu.com
+        id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
 
     - name: Add Microsoft packages source
       ansible.builtin.apt_repository:

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -19,7 +19,7 @@
         repo: "deb https://packages.microsoft.com/ubuntu/{{ ansible_facts.distribution_version }}/prod {{ ansible_facts.distribution_release }} main"
         state: present
         filename: microsoft-general
-        update_cache: false
+        update_cache: true
 
 - name: Set apt priorities
   tags: apt

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -15,6 +15,15 @@
         filename: microsoft-general
         update_cache: false
 
+- name: Set apt priorities
+  tags: apt
+  block:
+    - name: Set Microsoft repo priority
+      ansible.builtin.template:
+        src: etc/apt/preferences.d/microsoft-general.j2
+        dest: /etc/apt/preferences.d/microsoft-general
+        mode: 644
+
 - name: Apt packages
   tags: apt
   block:

--- a/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
+++ b/data_safe_haven/resources/workspace/ansible/tasks/packages.yaml
@@ -3,10 +3,11 @@
 - name: Microsoft packages repo
   tags: apt
   block:
-    - name: Import Microsoft package signing key
-      ansible.builtin.apt_key:
-        keyserver: keyserver.ubuntu.com
-        id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
+    - name: Fetch Microsoft package signing key
+      ansible.builtin.get_url:
+        url: https://packages.microsoft.com/keys/microsoft.asc
+        dest: /etc/apt/keyrings/microsoft.asc
+        checksum: sha256:2fa9c05d591a1582a9aba276272478c262e95ad00acf60eaee1644d93941e3c6
 
     - name: Add Microsoft packages source
       ansible.builtin.apt_repository:

--- a/data_safe_haven/resources/workspace/ansible/templates/etc/apt/preferences.d/microsoft-general.j2
+++ b/data_safe_haven/resources/workspace/ansible/templates/etc/apt/preferences.d/microsoft-general.j2
@@ -1,0 +1,5 @@
+Explanation: Prefer Microsoft releases of Microsoft Software
+Explanation: Priority installed < 400 < uninstalled
+Package: msodbcsql* dotnet*
+Pin: release o=microsoft-{{ ansible_facts.distribution_version }}-{{ ansible_facts.distribution_release }}-prod
+Pin-Priority: 400


### PR DESCRIPTION
- Update dotnet and msodbcsql packages
- ~~Replace deprecated method of importing package signing keys~~ Don't do this as 22.04 seems to have old OpenSSL/Curl preventing this.
- Add apt preference to hopefully prevent #2558 in the future