### PR TITLE
Documenting workspace's disks and updated the template file

### DIFF
--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -60,13 +60,14 @@ $ dsh config template --file PATH_YOU_WANT_TO_SAVE_YOUR_YAML_FILE_TO \
 :::{code} yaml
 azure:
   location: # Azure location where SRE resources will be deployed
-  subscription_id: # ID of the Azure subscription that the TRE will be deployed to
+  subscription_id: # ID of the Azure subscription that the SRE will be deployed to
   tenant_id: # Home tenant for the Azure account used to deploy infrastructure: `az account show`
-description: # A free-text description of your SRE deployment
+description: # Human-friendly name for this SRE deployment
 dockerhub:
-  access_token: # The password or personal access token for your Docker Hub account. We strongly recommend using a Personal Access Token with permissions set to Public Repo Read-only
-  username: # Your Docker Hub account name
-name: # A name for your SRE deployment containing only letters, numbers, hyphens and underscores
+  access_token: # A DockerHub personal access token (PAT) with ''Public Read-Only''
+    permissions. See instructions here: https://docs.docker.com/security/for-developers/access-tokens/'
+  username: # Your DockerHub username
+name: # A name for this config which consists only of letters, numbers and underscores
 sre:
   admin_email_address: # Email address shared by all administrators
   admin_ip_addresses: # List of IP addresses belonging to administrators
@@ -81,10 +82,28 @@ sre:
     - # You can also use the tag 'Internet' instead of a list
   software_packages: # Which Python/R packages to allow users to install: [any/pre-approved/none]
   storage_quota_gb:
-    home: # Total size in GiB across all home directories
-    shared: #Total size in GiB for the shared directories
+    data_disk: # Total size in GiB for the data disk [minimum: 0, maximum: 1023]
+    home: # Total size in GiB across all home directories [minimum: 100]
+    os_disk: # Total size in GiB for the OS disk [minimum: 64, maximum: 1023]
+    shared: #Total size in GiB for the shared directories [minimum: 100]
   timezone: # Timezone in pytz format (eg. Europe/London)
   workspace_skus: # List of Azure VM SKUs that will be used for data analysis.
+user_services:
+  dns_sidecar:
+    cron_expression: # Cron-formatted repeating schedule ('* * * * *') for DNS update
+    replica_timeout: # Maximum number of seconds a DNS sidecar job is allowed to run
+    retry_limit: # Maximum number of retries before failing the DNS sidecar job
+    workload_maximum_count: # Maximum capacity of the workload profile for the managed environment.
+    workload_minimum_count: # Minimum capacity of the workload profile for the managed
+      environment
+  gitea_mirror:
+    repositories:
+    - repository_auth_token: # A read-only GitHub personal access token, with access
+        to the repository to mirror
+      repository_name: # An identifier for the GitHub repository to mirror
+      repository_url: # The URL of the GitHub repository to mirror
+  nexus:
+    persistent_quota_gb: # Total size in GiB for Nexus persistent directory
 :::
 
 ::::

--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -90,7 +90,7 @@ sre:
   workspace_skus: # List of Azure VM SKUs that will be used for data analysis.
 user_services:
   dns_sidecar:
-    cron_expression: # Cron-formatted repeating schedule ('* * * * *') for DNS update
+    cron_expression: # Cron-formatted repeating schedule for DNS update
     replica_timeout: # Maximum number of seconds a DNS sidecar job is allowed to run
     retry_limit: # Maximum number of retries before failing the DNS sidecar job
     workload_maximum_count: # Maximum capacity of the workload profile for the managed environment.

--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -96,8 +96,7 @@ user_services:
     workload_minimum_count: # Minimum capacity of the workload profile for the managed environment
   gitea_mirror:
     repositories:
-    - repository_auth_token: # A read-only GitHub personal access token, with access
-        to the repository to mirror
+    - repository_auth_token: # A read-only GitHub personal access token, with access to the repository to mirror
       repository_name: # An identifier for the GitHub repository to mirror
       repository_url: # The URL of the GitHub repository to mirror
   nexus:

--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -64,8 +64,7 @@ azure:
   tenant_id: # Home tenant for the Azure account used to deploy infrastructure: `az account show`
 description: # Human-friendly name for this SRE deployment
 dockerhub:
-  access_token: # A DockerHub personal access token (PAT) with ''Public Read-Only''
-    permissions. See instructions here: https://docs.docker.com/security/for-developers/access-tokens/'
+  access_token: # A DockerHub personal access token (PAT) with ''Public Read-Only'' permissions. See instructions here: https://docs.docker.com/security/for-developers/access-tokens/'
   username: # Your DockerHub username
 name: # A name for this config which consists only of letters, numbers and underscores
 sre:

--- a/docs/source/deployment/deploy_sre.md
+++ b/docs/source/deployment/deploy_sre.md
@@ -93,8 +93,7 @@ user_services:
     replica_timeout: # Maximum number of seconds a DNS sidecar job is allowed to run
     retry_limit: # Maximum number of retries before failing the DNS sidecar job
     workload_maximum_count: # Maximum capacity of the workload profile for the managed environment.
-    workload_minimum_count: # Minimum capacity of the workload profile for the managed
-      environment
+    workload_minimum_count: # Minimum capacity of the workload profile for the managed environment
   gitea_mirror:
     repositories:
     - repository_auth_token: # A read-only GitHub personal access token, with access

--- a/docs/source/management/sre.md
+++ b/docs/source/management/sre.md
@@ -86,3 +86,9 @@ Therefore, after an SRE has been deployed, some changes can only be made from IP
 
 As a consequence, if you want to update the list of administrator IP addresses, for example to add a new administrator, you must do so from an IP address that is already allowed.
 ::::
+
+::::{admonition} Changing disk sizes
+:class: warning
+Updating the size of either the OS disk or the data disk is not possible via DSH [due to Pulumi limitations](https://github.com/pulumi/pulumi-azure-native/issues/3952).
+These changes need to happen manually after VM deallocation.
+::::

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -256,7 +256,6 @@ Fast storage may be available to a workspace within the SRE.
 This storage has good performance for work reading, writing or manipulating files.
 However, these directories are **local to each workspace** so any files will not be visible on another workspace.
 
-- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your {ref}`system manager <role_system_manager>`.
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.
   If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one workstation only** and can only be accessed from it.
   If you want to share information between workspaces, please check the {ref}`the section on sharing files <role_researcher_shared_storage>`.

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -251,10 +251,10 @@ Type `yes` to install the packages.
 
 The following disks can be available to a workspace within the SRE:
 
-- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
+- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your {ref}`system manager <role_system_manager>`.
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.
-  If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it.
-  If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
+  If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one workstation only** and can only be accessed from it.
+  If you want to share information between workspaces, please check the {ref}`the section on sharing files <role_researcher_shared_storage>`.
 - The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy. As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
 
 ## {{open_file_folder}} Sharing files inside the SRE

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -250,6 +250,22 @@ Type `yes` to install the packages.
 
 ## {{file_cabinet}} Storage in the SRE
 
+A number storage options are available in an SRE.
+Some storage is shared between all workspaces, others restricted to a particular workspace.
+The performance and permissions vary across the available storage.
+This section describes each type of storage.
+
+A summary of the storage and its recommended use is presented here
+
+| Storage      | Path             | Recommended use                                                                             |
+|--------------|------------------|---------------------------------------------------------------------------------------------|
+| Data disk    | `/mnt/datadrive` | Data intensive work                                                                         |
+| Scratch disk | `/mnt/scratch`   | Data intensive work, volatile storage                                                       |
+| Home         | `/home/$USER`    | Personal configuration                                                                      |
+| Input        | `/mnt/input`     | Depositing read-only copy of input data                                                     |
+| Shared       | `/mnt/shared`    | Sharing data between workspaces<br />Low intensity collaborative work (for example writing) |
+| Output       | `/mnt/output`    | Depositing proposed outputs to be reviewed for release                                      |
+
 (role_researcher_high_performance_storage)=
 
 ### {{computer_disk}} High performance storage

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -252,7 +252,9 @@ Type `yes` to install the packages.
 The following disks can be available to a workspace within the SRE:
 
 - The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
-- The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance. If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it. If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
+- The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.
+  If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it.
+  If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
 - The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy. As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
 
 ## {{open_file_folder}} Sharing files inside the SRE

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -246,26 +246,37 @@ to install packages into? (yes/No/cancel)
 
 Type `yes` to install the packages.
 
+(role_researcher_storage)=
+
+## {{file_cabinet}} Storage in the SRE
+
 (role_researcher_high_performance_storage)=
 
-## {{computer_disk}} High performance storage
+### {{computer_disk}} High performance storage
 
 Fast storage may be available to a workspace within the SRE.
 This storage has good performance for work reading, writing or manipulating files.
 However, these directories are **local to each workspace** so any files will not be visible on another workspace.
 
-- The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.
-  If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one workstation only** and can only be accessed from it.
-  If you want to share information between workspaces, please check the {ref}`the section on sharing files <role_researcher_shared_storage>`.
-- The *temporary disk* is not available to every workspace.
-  When present, researchers can write and read to `/mnt/scratch`.
-  Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage.
-  Data can be lost during a maintenance event, like a redeploy.
-  As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
+(role_researcher_data_disk)=
+
+#### Data disk
+
+The data disk, at **/mnt/datadrive**, is available to all researchers and it is meant to store data with good read/write performance.
+If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one worksspace only** and can only be accessed from it.
+  If you want to share information between workspaces, you can use one of the {ref}`shared directories <role_researcher_shared_storage>`.
+
+#### Scratch disk
+
+The scratch disk is not available to every workspace.
+When present, researchers can write and read to **/mnt/scratch**.
+Write and read performance is very good, however, it is only meant for short-term storage.
+Data can be lost during a maintenance event, like a redeploy.
+As with the {ref}`role_researcher_data_disk`, scratch disks are attached to a specific workspace and can only be accessed from it.
 
 (role_researcher_shared_storage)=
 
-## {{open_file_folder}} Sharing files inside the SRE
+### {{open_file_folder}} Sharing files inside the SRE
 
 There are several shared folder on each workspace that all collaborators within a research project team can see and access:
 
@@ -273,7 +284,7 @@ There are several shared folder on each workspace that all collaborators within 
 - [shared space](#shared-space): in the **/mnt/shared/** folder
 - [output resources](#output-resources): in the **/mnt/output/** folder
 
-### Input data
+#### Input data
 
 Data that has been approved and brought into the secure research environment can be found in the **/mnt/input/** folder.
 
@@ -288,7 +299,7 @@ You will not be able to change any of the files in **/mnt/input/**.
 If you want to make derived datasets, for example cleaned and reformatted data, please add those to the **/mnt/shared/** or **/mnt/output/** folders.
 :::
 
-### Shared space
+#### Shared space
 
 The **/mnt/shared/** folder should be used for any work that you want to share with your group.
 
@@ -296,7 +307,7 @@ The **/mnt/shared/** folder should be used for any work that you want to share w
 - Everyone working on your project will be able to access it
 - Everyone has **read-and-write access** to the files stored here.
 
-### Output resources
+#### Output resources
 
 Any outputs that you want to extract from the secure environment should be placed in the **/mnt/output/** folder on the workspace.
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -257,14 +257,14 @@ This section describes each type of storage.
 
 A summary of the storage and its recommended use is presented here
 
-| Storage      | Path             | Recommended use                                                                             |
-|--------------|------------------|---------------------------------------------------------------------------------------------|
-| Data disk    | `/mnt/datadrive` | Data intensive work                                                                         |
-| Scratch disk | `/mnt/scratch`   | Data intensive work, volatile storage                                                       |
-| Home         | `/home/$USER`    | Personal configuration                                                                      |
-| Input        | `/mnt/input`     | Depositing read-only copy of input data                                                     |
-| Shared       | `/mnt/shared`    | Sharing data between workspaces<br />Low intensity collaborative work (for example writing) |
-| Output       | `/mnt/output`    | Depositing proposed outputs to be reviewed for release                                      |
+| Storage                                                | Path               | Recommended use                                                                               |
+| ------------------------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------- |
+| {ref}`Data disk <role_researcher_data_disk>`           | `/mnt/datadrive`   | Data intensive work                                                                           |
+| {ref}`Scratch disk <role_researcher_shared_storage>`   | `/mnt/scratch`     | Data intensive work, volatile storage                                                         |
+| Home                                                   | `/home/$USER`      | Personal configuration                                                                        |
+| {ref}`Input <role_researcher_input>`                   | `/mnt/input`       | Depositing read-only copy of input data                                                       |
+| {ref}`Shared <role_researcher_shared>`                 | `/mnt/shared`      | Sharing data between workspaces<br />Low intensity collaborative work (for example writing)   |
+| {ref}`Output <role_researcher_output>`                 | `/mnt/output`      | Depositing proposed outputs to be reviewed for release                                        |
 
 (role_researcher_high_performance_storage)=
 
@@ -281,6 +281,8 @@ However, these directories are **local to each workspace** so any files will not
 The data disk, at **/mnt/datadrive**, is available to all researchers and it is meant to store data with good read/write performance.
 If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one worksspace only** and can only be accessed from it.
   If you want to share information between workspaces, you can use one of the {ref}`shared directories <role_researcher_shared_storage>`.
+
+(role_researcher_scratch_disk)=
 
 #### Scratch disk
 
@@ -300,6 +302,8 @@ There are several shared folder on each workspace that all collaborators within 
 - [shared space](#shared-space): in the **/mnt/shared/** folder
 - [output resources](#output-resources): in the **/mnt/output/** folder
 
+(role_researcher_input)=
+
 #### Input data
 
 Data that has been approved and brought into the secure research environment can be found in the **/mnt/input/** folder.
@@ -315,6 +319,8 @@ You will not be able to change any of the files in **/mnt/input/**.
 If you want to make derived datasets, for example cleaned and reformatted data, please add those to the **/mnt/shared/** or **/mnt/output/** folders.
 :::
 
+(role_researcher_shared)=
+
 #### Shared space
 
 The **/mnt/shared/** folder should be used for any work that you want to share with your group.
@@ -322,6 +328,8 @@ The **/mnt/shared/** folder should be used for any work that you want to share w
 - The contents of **/mnt/shared/** will be identical on all workspaces in your SRE.
 - Everyone working on your project will be able to access it
 - Everyone has **read-and-write access** to the files stored here.
+
+(role_researcher_output)=
 
 #### Output resources
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -253,9 +253,7 @@ The following disks can be available to a workspace within the SRE:
 
 - The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you are not able to write to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance. If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it. If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
-- The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy.
-As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
-
+- The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy. As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
 
 ## {{open_file_folder}} Sharing files inside the SRE
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -249,7 +249,9 @@ Type `yes` to install the packages.
 
 ## {{computer_disk}} High performance storage
 
-The following disks can be available to a workspace within the SRE:
+Fast storage may be available to a workspace within the SRE.
+This storage has good performance for work reading, writing or manipulating files.
+However, these directories are **local to each workspace** so any files will not be visible on another workspace.
 
 - The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your {ref}`system manager <role_system_manager>`.
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -255,7 +255,11 @@ The following disks can be available to a workspace within the SRE:
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance.
   If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one workstation only** and can only be accessed from it.
   If you want to share information between workspaces, please check the {ref}`the section on sharing files <role_researcher_shared_storage>`.
-- The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy. As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
+- The *temporary disk* is not available to every workspace.
+  When present, researchers can write and read to `/mnt/scratch`.
+  Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage.
+  Data can be lost during a maintenance event, like a redeploy.
+  As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
 
 ## {{open_file_folder}} Sharing files inside the SRE
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -246,8 +246,6 @@ to install packages into? (yes/No/cancel)
 
 Type `yes` to install the packages.
 
-(role_researcher_shared_storage)=
-
 (role_researcher_high_performance_storage)=
 
 ## {{computer_disk}} High performance storage
@@ -264,6 +262,8 @@ However, these directories are **local to each workspace** so any files will not
   Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage.
   Data can be lost during a maintenance event, like a redeploy.
   As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
+
+(role_researcher_shared_storage)=
 
 ## {{open_file_folder}} Sharing files inside the SRE
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -251,7 +251,7 @@ Type `yes` to install the packages.
 
 The following disks can be available to a workspace within the SRE:
 
-- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you are not able to write to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
+- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you have very limited write access to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
 - The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance. If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it. If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
 - The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy. As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -74,6 +74,7 @@ While working on the project:
 - store anything that might form an output from the project (_e.g._ images, documents or output datasets) in the **/mnt/output/** folder.
 
 See {ref}`the section on sharing files <role_researcher_shared_storage>` to find out more about where to store your files.
+Also, see {ref}`the section in high-performance storage <role_researcher_high_performance_storage>` if you will be performing resource-intensive tasks, like programming or data analysis.
 
 ## {{package}} Pre-installed applications
 
@@ -246,6 +247,8 @@ to install packages into? (yes/No/cancel)
 Type `yes` to install the packages.
 
 (role_researcher_shared_storage)=
+
+(role_researcher_high_performance_storage)=
 
 ## {{computer_disk}} High performance storage
 

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -247,6 +247,16 @@ Type `yes` to install the packages.
 
 (role_researcher_shared_storage)=
 
+## {{computer_disk}} Working with disks
+
+The following disks can be available to a workspace within the SRE:
+
+- The *operating system disk*, available at `/`, contains the operating system. As a researcher, **you are not able to write to this disk**. If by any chance you require access, for example you might need to install software as root, please get in touch with your System Manager.
+- The *data disk*, at `/mnt/datadrive`, is available to all researchers and it is meant to store data with good read/write performance. If present (if not, talk to your System Manager) each data disk **is attached to one workstation only** and can only be accessed from it. If you want to share information between workspaces, please check the "Sharing files inside the SRE" section below.
+- The *temporary disk* is not available to every workspace. When present, researchers can write and read to `/mnt/scratch`. Write and read performance to the temporary disk is very good, however, it is only meant for short-term storage. Data can be lost during a maintenance event, like a redeploy.
+As with a data disk, temporary disks are attached to a specific workspace and can only be accessed from it.
+
+
 ## {{open_file_folder}} Sharing files inside the SRE
 
 There are several shared folder on each workspace that all collaborators within a research project team can see and access:

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -279,7 +279,7 @@ However, these directories are **local to each workspace** so any files will not
 #### Data disk
 
 The data disk, at **/mnt/datadrive**, is available to all researchers and it is meant to store data with good read/write performance.
-If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one worksspace only** and can only be accessed from it.
+If present (if not, talk to your {ref}`system manager <role_system_manager>`) each data disk **is attached to one workspace only** and can only be accessed from it.
   If you want to share information between workspaces, you can use one of the {ref}`shared directories <role_researcher_shared_storage>`.
 
 (role_researcher_scratch_disk)=

--- a/docs/source/roles/researcher/using_the_sre.md
+++ b/docs/source/roles/researcher/using_the_sre.md
@@ -247,7 +247,7 @@ Type `yes` to install the packages.
 
 (role_researcher_shared_storage)=
 
-## {{computer_disk}} Working with disks
+## {{computer_disk}} High performance storage
 
 The following disks can be available to a workspace within the SRE:
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A

### :arrow_heading_up: Summary

We have added user-facing documentation for the following features:

- Data disks, introduced by PR https://github.com/alan-turing-institute/data-safe-haven/pull/2532
- Scratch disks, enabled by PR https://github.com/alan-turing-institute/data-safe-haven/pull/2432

In this PR, we also updated the template config file, to reflect the new options available.

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes: https://github.com/alan-turing-institute/data-safe-haven/issues/2563

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Documentation built locally:

<img width="1246" height="709" alt="image" src="https://github.com/user-attachments/assets/5c8c79bc-57d3-4049-9fa7-5cc0a70298ed" />

