### PR TITLE
Using specific versions of hatch and virtualenv for our pipelines

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -2,7 +2,7 @@
 name: Build documentation
 
 # Run workflow on pushes to matching branches
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches: [develop, latest]
   pull_request:
@@ -21,8 +21,8 @@ jobs:
           python-version: 3.12
 
       - name: Install hatch
-        run: pip install hatch
-
+        run: pip install virtualenv==20.39.0 hatch==1.16.3
+        # Temporary workaround. virtualenv==21.0.0 breaks the GH Action.
       - name: Build documentation
         run: hatch run docs:build
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
-             lychee.toml
+            lychee.toml
           sparse-checkout-cone-mode: false
 
       - name: Ensure destination folder exists
@@ -67,4 +67,4 @@ jobs:
         with:
           lycheeVersion: v0.22.0 # To avoid a bug in 0.21 where no file are found, should be revised as the action is updated
           args: --verbose --no-progress --extensions 'html' './docs/build/html/'
-          fail: true  # fail on broken links
+          fail: true # fail on broken links

--- a/.github/workflows/lint_code.yaml
+++ b/.github/workflows/lint_code.yaml
@@ -2,7 +2,7 @@
 name: Lint code
 
 # Run workflow on pushes to matching branches
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches: [develop, latest]
   pull_request:
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: "3.3"
       - name: Install requirements
         shell: bash
         run: gem install mdl
@@ -68,7 +68,8 @@ jobs:
         with:
           python-version: 3.12
       - name: Install hatch
-        run: pip install hatch
+        run: pip install virtualenv==20.39.0 hatch==1.16.3
+        # Temporary workaround. virtualenv==21.0.0 breaks the GH Action.
       - name: Print package versions
         run: |
           hatch run lint:ruff --version

--- a/.github/workflows/test_code.yaml
+++ b/.github/workflows/test_code.yaml
@@ -2,7 +2,7 @@
 name: Test code
 
 # Run workflow on PRs and pushes to matching branches
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches: [develop, latest]
   pull_request:
@@ -26,7 +26,8 @@ jobs:
         with:
           python-version: 3.12
       - name: Install hatch
-        run: pip install hatch
+        run: pip install virtualenv==20.39.0 hatch==1.16.3
+        # Temporary workaround. virtualenv==21.0.0 breaks the GH Action.
       - name: Test Python
         run: hatch run test:test-coverage
       # For security reasons, PRs created from forks cannot generate PR comments directly


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

### :arrow_heading_up: Summary

The `virtualenv==21.0.0` breaks Hatch (see: https://github.com/pypa/hatch/issues/2193) which in turn breaks our CI/CD pipelines. This is a temporary workaround until a permanent fix is delivered.

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->
