### PR TITLE
Read allowlist templates from correct path

### DIFF
--- a/data_safe_haven/commands/allowlist.py
+++ b/data_safe_haven/commands/allowlist.py
@@ -12,7 +12,9 @@ from data_safe_haven.exceptions import DataSafeHavenConfigError, DataSafeHavenEr
 from data_safe_haven.external import AzureSdk
 from data_safe_haven.infrastructure import SREProjectManager
 from data_safe_haven.logging import get_logger
+from data_safe_haven.resources import resources_path
 from data_safe_haven.types import AllowlistRepository, SoftwarePackageCategory
+from data_safe_haven.utility import FileReader
 
 allowlist_command_group = typer.Typer()
 
@@ -120,14 +122,13 @@ def template(
 ) -> None:
     """Print a template for the package allowlist"""
 
-    template_path = Path(
-        "data_safe_haven/resources",
-        "software_repositories",
-        "allowlists",
-        f"{repository.value}.allowlist",
+    template_reader = FileReader(
+        resources_path
+        / "software_repositories"
+        / "allowlists"
+        / f"{repository.value}.allowlist"
     )
-    with open(template_path) as f:
-        example_allowlist = f.read()
+    example_allowlist = template_reader.file_contents()
     if file:
         with open(file, "w") as f:
             f.write(example_allowlist)

--- a/tests/commands/test_allowlist.py
+++ b/tests/commands/test_allowlist.py
@@ -1,3 +1,6 @@
+from os import chdir
+from pathlib import Path
+
 from pytest import fixture, mark
 
 from data_safe_haven.allowlist import Allowlist
@@ -118,6 +121,25 @@ class TestTemplateAllowlist:
             assert "DBI\nMASS" in result.output
         elif repository == "pypi":
             assert "numpy\npackaging" in result.output
+
+    @mark.parametrize(
+        "repository",
+        [
+            "cran",
+            "pypi",
+        ],
+    )
+    def test_template_other_dir(self, runner, repository) -> None:
+        # Change to a different directory
+        cwd = Path.cwd()
+        chdir(Path(__file__).parent)
+        try:
+            self.test_template(runner, repository)
+        except Exception as err:
+            raise err
+        finally:
+            # Always restore the original working directory
+            chdir(cwd)
 
 
 class TestUploadAllowlist:


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

N/A.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

The allowlist templates were being read from a path relative to the CWD. This meant that they would be correctly output, but only if the command was run from inside the root of the data-save-haven working directory. This updates the code to read the files correctly from the resource directory irrespective of the CWD.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Closes #2533

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Tested by running the following commands:
```sh
cd data-safe-haven
dsh allowlist template pypi
pushd ..
dsh allowlist template pypi
popd
```

Previously the second call to `dsh` would generate an error, but after this change it no longer does. I've also added a new unit test to perform roughly the same check (changes directory, requests template, restores directory). The test fails with previous versions of the code but passes after the changes here.

I specifically chose this issue while I'm awaiting access to the dev SRE, because it only relies on code running locally (and it was an easy fix while I get familiar with the code and processes).