### PR TITLE
Remove noexec flag from datadrive mount

### DIFF
--- a/data_safe_haven/resources/dns_server/dns_server_vm.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/dns_server/dns_server_vm.cloud_init.mustache.yaml
@@ -61,6 +61,11 @@ runcmd:
   - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
   - systemctl reload-or-restart systemd-resolved
 
+  # Wait while port 53 is released
+  # ---------------------------
+  - echo ">=== Wait for port 53 to be released... ===<"
+  - sleep 8
+
   # Run the adguardhome service
   # ---------------------------
   - echo ">=== Run the adguardhome service... ===<"

--- a/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
+++ b/data_safe_haven/resources/workspace/workspace.cloud_init.mustache.yaml
@@ -52,7 +52,7 @@ mounts:
   - [ephemeral0, /mnt/scratch]
   {{#data_disk_support}}
   # Mounting data disk
-  - ["/dev/disk/azure/scsi1/lun0-part1", "/mnt/datadrive", auto, "defaults,noexec,nofail"]
+  - ["/dev/disk/azure/scsi1/lun0-part1", "/mnt/datadrive", auto, "defaults,nofail"]
   {{/data_disk_support}}
   # Desired state configuration is in a blob container mounted as NFSv3
   - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}/desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]

--- a/docs/source/deployment/security_checklist.md
+++ b/docs/source/deployment/security_checklist.md
@@ -2,10 +2,10 @@
 
 # Security evaluation checklist
 
-```{caution}
+:::{caution}
 This security checklist is used by the Alan Turing Institute to evaluate compliance with our default controls.
 Organisations are responsible for making their own decisions about the suitability of any of our default controls and should treat this checklist as an example, not a template to follow.
-```
+:::
 
 In this check list we aim to evaluate our deployment against the {ref}`security configuration <design_turing_security_configuration>` that we apply at the Alan Turing Institute.
 A copy of this template in Markdown format is {download}`available for download <security_checklist/security_checklist_template.md>`.
@@ -16,10 +16,12 @@ The security checklist currently focuses on checks that can evaluate these secur
 Ensure you have met the [](#prerequisites).
 Work your way through the actions described in each section, taking care to notice each time you see a {{camera}} or a {{white_check_mark}} and the word Verify.
 
-```{note}
+:::{note}
+
 - {{camera}} Where you see the camera icon, there should be accompanying screenshot(s) of evidence for this item in the checklist (you may wish to save your own equivalent screenshots as evidence)
 - {{white_check_mark}} This indicates a checklist item for which a screenshot is either not appropriate or difficult
-```
+
+:::
 
 You can use {download}`this template Markdown file <./security_checklist/security_checklist_template.md>` to complete the checklist.
 
@@ -77,34 +79,34 @@ Do not register this user with any SRE yet.
 - Click "Forgotten my password".
 - Reset password.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
  <details><summary> user can reset their own password</summary>
 
-```{image} security_checklist/sspr.png
+:::{image} security_checklist/sspr.png
 :align: center
-```
-```{image} security_checklist/sspr_success.png
+:::
+:::{image} security_checklist/sspr_success.png
 :align: center
-```
+:::
 
 </details>
-````
+::::
 
 #### Check: Non-registered users cannot connect to any SRE workspace
 
 Attempt to login to the remote desktop web client as the research user.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
  <details><summary>user can authenticate but cannot see any workspaces</summary>
 
-```{image} security_checklist/no_valid_workspaces.png
+:::{image} security_checklist/no_valid_workspaces.png
 :align: center
-```
+:::
 
 </details>
-````
+::::
 
 #### Check: Registered users can see SRE workspaces
 
@@ -112,16 +114,16 @@ Check that the research user can authenticate using MFA and is granted access to
 
 - Login to the remote desktop web client as the research user.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 <details><summary>user can authenticate and can see workspaces</summary>
 
-```{image} security_checklist/valid_workspaces.png
+:::{image} security_checklist/valid_workspaces.png
 :align: center
-```
+:::
 
 </details>
-````
+::::
 
 #### Check: Authenticated user can access workspaces
 
@@ -130,16 +132,16 @@ Check that the research user can access a workspace.
 - Login to the remote desktop web client as the research user.
 - Select a workspace and login as the research user.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 <details><summary>you can connect to any workspace</summary>
 
-```{image} security_checklist/workspace_xfce_initial.png
+:::{image} security_checklist/workspace_xfce_initial.png
 :align: center
-```
+:::
 
 </details>
-````
+::::
 
 ## 2. Isolated Network
 
@@ -160,32 +162,32 @@ Check that the research user can access a workspace.
 - Connect to an SRE workspace by using the web client.
 - Attempt to access the internet using a browser and CLI tools.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>browsing to the service fails</i></summary>
 
-```{image} security_checklist/no_internet_browser.png
+:::{image} security_checklist/no_internet_browser.png
 :align: center
-```
+:::
 
 </details>
 
 <details><summary>you cannot access the service using curl</summary>
 
-```{image} security_checklist/no_internet_curl.png
+:::{image} security_checklist/no_internet_curl.png
 :align: center
-```
+:::
 
 </details>
 
 <details><summary>you cannot look up the IP address for the service using nslookup</summary>
 
-```{image} security_checklist/no_nslookup.png
+:::{image} security_checklist/no_nslookup.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
 ## 3. User devices
 
@@ -205,43 +207,43 @@ Check that the research user can access a workspace.
 
 - Connect to the environment using an allowed IP address and credentials
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection succeeds
-```
+:::
 
 - Connect to the environment from an IP address that is not allowed but with correct credentials.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection fails
-```
+:::
 
 #### User devices ({ref}`policy_tier_3`)
 
 All managed devices should be provided by a known IT team at an approved organisation.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the IT team of the approved organisation take responsibility for managing the device.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the user does not have administrator permissions on the device.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: allowed IP addresses are exclusive to managed devices.
-```
+:::
 
 - Connect to the environment using an allowed IP address and credentials
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection succeeds
-```
+:::
 
 - Connect to the environment from an IP address that is not allowed but with correct credentials.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection fails
-```
+:::
 
 #### Network rules ({ref}`policy_tier_2` and above):
 
@@ -249,20 +251,20 @@ There are network rules permitting access to the portal from allowed IP addresse
 
 - In the Azure portal navigate to the Guacamole application gateway NSG for this SRE `shm-<SHM ID>-sre-<SRE ID>-nsg-application-gateway`.
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>the NSG has network rules allowing Inbound access from allowed IP addresses only</summary>
 
-```{image} security_checklist/nsg_inbound_access.png
+:::{image} security_checklist/nsg_inbound_access.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: all other NSGs have an inbound `Deny All` rule and no higher priority rule allowing inbound connections from outside the Virtual Network.
-```
+:::
 
 ## 4. Physical security
 
@@ -285,25 +287,25 @@ Connection from outside the secure physical space is not possible.
 
 - Attempt to connect to the {ref}`policy_tier_3` SRE web client from home using a managed device and the correct VPN connection and credentials.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection fails.
-```
+:::
 
 Connection from within the secure physical space is possible.
 
 - Attempt to connect from research office using a managed device and the correct VPN connection and credentials.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: connection succeeds.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: check the network IP ranges corresponding to the research spaces and compare against the IPs accepted by the firewall.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: confirm in person that physical measures such as screen adaptions or desk partitions are present if risk of visual eavesdropping is high.
-```
+:::
 
 ## 5. Remote connections
 
@@ -321,35 +323,35 @@ Connection from within the secure physical space is possible.
 
 - Attempt to login as the research user via SSH with `ssh <user.name>@<SRE ID>.<safe haven domain>` (e.g. `ssh -v -o ConnectTimeout=10 ada.lovelace@sandbox.turingsafehaven.ac.uk`).
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>SSH login by fully-qualified domain name fails</summary>
 
-```{image} security_checklist/no_ssh_fqdn.png
+:::{image} security_checklist/no_ssh_fqdn.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
 - Find the public IP address for the remote desktop web client.
     - {{pear}} This will be given by the resource `shm-<SHM ID>-sre-<SRE ID>-public-ip`.
 - Attempt to login as the research user via `SSH` with `ssh <user.name>@<public IP>` (_e.g._ `ssh ada.lovelace@8.8.8.8`).
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>SSH login by public IP address fails</summary>
 
-```{image} security_checklist/no_ssh_ip.png
+:::{image} security_checklist/no_ssh_ip.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the remote desktop web client application gateway (`shm-<SHM ID>-sre-<SRE ID>-ag-entrypoint`), and the firewall, are the only SRE resources with public IP addresses.
-```
+:::
 
 ## 6. Copy-and-paste
 
@@ -370,16 +372,16 @@ Connection from within the secure physical space is possible.
 - Connect to a workspace as the research user via the remote desktop web client.
 - Open a text editor or terminal on the SRD and attempt to paste the text to it.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: paste fails
-```
+:::
 
 - Write some text in a text editor or terminal of the workspace and copy it.
 - Attempt to paste the text on your local device.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: paste fails
-```
+:::
 
 ## 7. Data ingress
 
@@ -409,49 +411,49 @@ To minimise the risk of unauthorised access to the dataset while the ingress vol
 - Use the IP address of your own device in place of that of the data provider.
 - Generate an upload token with only Write and List permissions.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the upload token is successfully created.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: you are able to send this token using a secure mechanism.
-```
+:::
 
 #### Ensure that data ingress works only for connections from the accepted IP address range
 
 - As the {ref}`role_data_provider_representative`, ensure you're working from a device that has an allowed IP address.
 - Using the upload token with write-only permissions and limited time period that you set up in the previous step, follow the ingress instructions for the {ref}`data provider <role_data_provider_representative>`.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: writing succeeds by uploading a file
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: attempting to open or download any of the files results in the following error: `Failed to start transfer: Insufficient credentials.` under the `Activities` pane at the bottom of the MS Azure Storage Explorer window.
-```
+:::
 
 - Switch to a device without an allowed IP address (or change your IP with a VPN)
 - Attempt to write to the ingress volume via the test device
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the access token fails.
-```
+:::
 
 #### Check that the upload fails if the token has expired
 
 - Create a write-only token with short duration
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: you can connect and write with the token during the duration
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: you cannot connect and write with the token after the duration has expired
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the data ingress process works by uploading different kinds of files, e.g. data, images, scripts (if appropriate).
-```
+:::
 
 ## 8. Data egress
 
@@ -471,25 +473,25 @@ To minimise the risk of unauthorised access to the dataset while the ingress vol
 - Login to an SRD as the research user via the remote desktop web client
 - Open up a file explorer and search for the various storage volumes
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the `/mnt/output` volume exists and can be read and written to.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: the permissions of other storage volumes match that described in the [user guide](../roles/researcher/using_the_sre.md#-sharing-files-inside-the-sre).
-```
+:::
 
 #### Confirm that {ref}`role_system_manager` can see and download files from output
 
 - As the {ref}`role_system_manager`, follow the instructions in the [project manager documentation](../roles/project_manager/data_egress.md#data-egress-process) on how to access files set for egress with `Azure Storage Explorer`.
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: you can see the files written to the `/mnt/output` storage volume.
-```
+:::
 
-```{attention}
+:::{attention}
 {{white_check_mark}} Verify that: a written file can be taken out of the environment via download
-```
+:::
 
 ## 9. Software package repositories
 
@@ -510,55 +512,55 @@ To minimise the risk of unauthorised access to the dataset while the ingress vol
 - Connect to a Tier 2 workspace as the research user via remote desktop web client.
 - Attempt to install a package on the allowed list that is not included out-of-the-box (for example, try `python -m venv ./venv && source ./venv/bin/activate && pip install pytz`)
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>you can install the package</summary>
 
-```{image} security_checklist/pypi_t2_allowed.png
+:::{image} security_checklist/pypi_t2_allowed.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
 - Then attempt to install any package that is not on the allowed list (for example, try `pip install -q awscli`)
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>you can install the package</summary>
 
-```{image} security_checklist/pypi_t2_disallowed.png
+:::{image} security_checklist/pypi_t2_disallowed.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
 #### {ref}`policy_tier_3`: Download a package on the allow list and one not on the allow list
 
 - Connect to a Tier 3 workspace as the research user via remote desktop web client.
 - Attempt to install a package on the allowed list that is not included out-of-the-box (for example, try `python -m venv ./venv && source ./venv/bin/activate && pip install pytz`).
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>you can install the package</summary>
 
-```{image} security_checklist/pypi_t3_allowed.png
+:::{image} security_checklist/pypi_t3_allowed.png
 :align: center
-```
+:::
 </details>
-````
+::::
 
 - Then attempt to download a package that is not included in the allowed list (for example, try `pip install awscli`).
 
-````{attention}
+::::{attention}
 {{camera}} <b>Verify that:</b>
 
 <details><summary>you cannot install the package</summary>
 
-```{image} security_checklist/pypi_t3_disallowed.png
+:::{image} security_checklist/pypi_t3_disallowed.png
 :align: center
-```
+:::
 </details>
-````
+::::

--- a/docs/source/design/index.md
+++ b/docs/source/design/index.md
@@ -13,9 +13,9 @@ We detail various decisions and constraints that have impacted the design of the
 This includes reasoning for our choices but also highlights potential limitations of our design and how this might affect things like security.
 In addition to describing the architecture and technical security controls configured when deploying a Data Safe Haven following our deployment guide, we also share some of the information governance policies and processes we use to manage the security of our Data Safe Haven instance at the Turing.
 
-```{warning}
+:::{warning}
 Each organisation deploying their own instance of the Data Safe Haven is responsible for verifying their Data Safe Haven instance is deployed and operates as expected and that the deployed configuration effectively supports the purpose for which they have deployed the Data Safe Haven and their own information governance policies and processes.
-```
+:::
 
 [Security](security/index.md)
 : Details about the security configuration used at the Alan Turing Institute

--- a/docs/source/design/security/objectives.md
+++ b/docs/source/design/security/objectives.md
@@ -4,15 +4,15 @@
 
 The diagram below shows an overview of the security objectives outlined in our [design choices](https://arxiv.org/abs/1908.08737) preprint.
 
-```{image} sample_security_controls.png
+:::{image} sample_security_controls.png
 :alt: Sample security controls
 :align: center
-```
+:::
 
-```{caution}
+:::{caution}
 The Alan Turing Institute does not yet operate any {ref}`policy_tier_4` environments and so our suggested default controls for {ref}`policy_tier_4` environments are still under development.
 Organisations are responsible for making their own decisions about the suitability of any of our default controls, but should be especially careful about doing so if considering using the Data Safe Haven for projects at the {ref}`policy_tier_4` sensitivity level.
-```
+:::
 
 ## Security considerations
 

--- a/docs/source/design/security/technical_controls.md
+++ b/docs/source/design/security/technical_controls.md
@@ -42,14 +42,14 @@ Most of these controls can be relaxed or tightened by the {ref}`role_system_mana
 
 ## Tier-specific
 
-```{caution}
+:::{caution}
 {ref}`policy_tier_4` defaults are not discussed below as such environments are not currently supported by the Data Safe Haven.
-```
+:::
 
-```{important}
+:::{important}
 While {ref}`policy_tier_0` and {ref}`policy_tier_1` are discussed below, at the Alan Turing Institute we do not generally use our Data Safe Haven for {ref}`policy_tier_0` or {ref}`policy_tier_1` environments.
 While SREs can be configured as {ref}`policy_tier_0` or {ref}`policy_tier_1`, we generally favour supporting researchers to apply sensible controls on organisational devices and standard cloud resources for such lower sensitivity projects.
-```
+:::
 
 ### Inbound connections
 
@@ -59,9 +59,9 @@ Access to the gateway is only permitted from defined IP addresses associated wit
 - **{ref}`policy_tier_2`:** Access is restricted to a defined set of IP addresses. At the Alan Turing Institute we permit access only from institutionally managed networks, which will generally be accessible to {ref}`Researchers <role_researcher>` not authorised to access the Data Safe Haven and might also be accessible to non-Researchers.
 - **{ref}`policy_tier_0` and {ref}`policy_tier_1`:** Access is permitted from any IP address by default. At the Alan Turing Institute we do not generally use our Data Safe Haven for {ref}`policy_tier_0` or {ref}`policy_tier_1`. Organisations choosing to do so may wish to consider only allowing inbound internet access from a specific range of networks {ref}`Researchers <role_researcher>` are known to work from.
 
-```{caution}
+:::{caution}
 Having no restrictions on which IP addresses can connect to the gateway increases the risk of external attacks, many of which may be untargeted but might still result in a degradation of service.
-```
+:::
 
 ### Outbound connections
 
@@ -83,9 +83,9 @@ Having no restrictions on which IP addresses can connect to the gateway increase
 - **{ref}`policy_tier_2` and {ref}`policy_tier_3`:** Copy-and-paste and file transfer between the SRE and the {ref}`Researcher's <role_researcher>` device are disabled.
 - **{ref}`policy_tier_0` and {ref}`policy_tier_1`:** Copy and paste is enabled between the SRE and the {ref}`Researcher's <role_researcher>` device is enabled but file transfer is not possible for non administrators.
 
-```{note}
+:::{note}
 Note that this means that eg. password managers cannot be used to autofill a {ref}`Researcher's <role_researcher>` SRE login credentials.
-```
+:::
 
 ### Sign-off on bringing data into the environment:
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,10 +13,10 @@ reference/index.md
 contributing/index.md
 :::
 
-```{image} _static/scriberia_diagram.jpg
+:::{image} _static/scriberia_diagram.jpg
 :alt: Data Safe Haven cartoon by Scriberia for The Alan Turing Institute
 :align: center
-```
+:::
 
 Many of the important questions we want to answer for society require the use of sensitive data.
 In order to effectively answer these questions, we need productive, secure environments to analyse that data.
@@ -57,7 +57,7 @@ This documentation is released under the [CC BY 4.0 Licence](https://creativecom
 
 ### Disclaimer
 
-```{warning}
+:::{warning}
 The Alan Turing Institute and its group companies ("we", "us", the "Turing") make no
 representations, warranties, or guarantees, express or implied, regarding the information contained
 on this site, including but not limited to information about the use or deployment of the Data
@@ -76,4 +76,4 @@ no guarantees regarding the safety, security or suitability of any instance(s) o
 the Data Safe Haven. The Turing assumes no responsibility for updating any of the content on this
 site; however, the underlying code and related materials may change from time to time with updates
 and it is the user's responsibility to keep abreast of these updates.
-```
+:::

--- a/docs/source/management/allowlist.md
+++ b/docs/source/management/allowlist.md
@@ -8,7 +8,7 @@ Packages not on the allowlist are blocked.
 
 An allowlist is a plain text file, with the name of each allowed package on its own line.
 
-```{important}
+::::{important}
 The user must also be able to download any dependencies of any package on the allowlist.
 You should ensure that any such dependencies are also added to the allowlist.
 
@@ -26,23 +26,23 @@ withr
 :::
 
 This includes the requested packages and their dependencies.
-```
+::::
 
 ## Viewing allowlists
 
 To view the current allowlist for a given repository, use {typer}`dsh allowlist show`
 
-```{code} shell
+:::{code} shell
 dsh allowlist show YOUR_SRE_NAME REPOSITORY_NAME
-```
+:::
 
 ## Uploading and updating an allowlist
 
 To upload an allowlist, use {typer}`dsh allowlist upload`.
 
-```{code} shell
+:::{code} shell
 dsh allowlist upload YOUR_SRE_NAME PATH_TO_ALLOWLIST_FILE REPOSITORY_NAME
-```
+:::
 
 The local allowlist file does not need to have a specific name.
 
@@ -50,6 +50,6 @@ The local allowlist file does not need to have a specific name.
 
 Example allowlists for PyPI and CRAN can be generated using {typer}`dsh allowlist template`
 
-```{code} shell
+:::{code} shell
 dsh allowlist template REPOSITORY_NAME
-```
+:::

--- a/docs/source/management/data.md
+++ b/docs/source/management/data.md
@@ -24,10 +24,10 @@ The following steps show how to generate a temporary, write-only upload token th
     - Leave everything else as default and click **{guilabel}`Generate SAS token and URL`**
     - Copy the **Blob SAS URL**
 
-      ```{image} ingress_token_write_only.png
+      :::{image} ingress_token_write_only.png
       :alt: write-only SAS token
       :align: center
-      ```
+      :::
 
 - Send the **Blob SAS URL** to the data provider through a secure channel
 - The data provider should now be able to upload data
@@ -39,10 +39,10 @@ The following steps show how to generate a temporary, write-only upload token th
 
 ## Data egress
 
-```{important}
+:::{important}
 Assessment of output must be completed **before** an egress link is created.
 Outputs are potentially sensitive, and so an appropriate process must be applied to ensure that they are suitable for egress.
-```
+:::
 
 The {ref}`role_system_manager` creates a time-limited and IP restricted link to remove data from the environment.
 
@@ -64,10 +64,10 @@ The {ref}`role_system_manager` creates a time-limited and IP restricted link to 
     - Leave everything else as default and press **{guilabel}`Generate SAS token and URL`**
     - Copy the **Blob SAS URL**
 
-      ```{image} egress_token_read_only.png
+      :::{image} egress_token_read_only.png
       :alt: Read-only SAS token
       :align: center
-      ```
+      :::
 
 - Send the **Blob SAS URL** to the relevant person through a secure channel
 - The appropriate person should now be able to download data

--- a/docs/source/management/sre.md
+++ b/docs/source/management/sre.md
@@ -4,13 +4,13 @@
 
 - Use {typer}`dsh config available` to check what SRE configurations are available in the current context, and whether those SREs are deployed.
 
-```{code} shell
+:::{code} shell
 $ dsh config available
-```
+:::
 
 will give output like the following
 
-```{code} shell
+:::{code} shell
 Available SRE configurations for context 'green':
 ┏━━━━━━━━━━━━━━┳━━━━━━━━━━┓
 ┃ SRE Name     ┃ Deployed ┃
@@ -19,15 +19,15 @@ Available SRE configurations for context 'green':
 │ jade         │          │
 │ olive        │          │
 └──────────────┴──────────┘
-```
+:::
 
 ## Remove a deployed Data Safe Haven
 
 - Use {typer}`dsh sre teardown` to teardown a deployed SRE:
 
-```{code} shell
+:::{code} shell
 $ dsh sre teardown YOUR_SRE_NAME
-```
+:::
 
 ::::{admonition} Tearing down an SRE is destructive and irreversible
 :class: danger
@@ -39,9 +39,9 @@ The user groups for the SRE on Microsoft Entra ID will also be deleted.
 
 - Use {typer}`dsh shm teardown` if you want to teardown the deployed SHM:
 
-```{code} shell
+:::{code} shell
 $ dsh shm teardown
-```
+:::
 
 ::::{admonition} Tearing down an SHM
 :class: warning
@@ -56,28 +56,28 @@ SREs are modified by updating the configuration then running the deploy command.
 
 - The existing configuration for the SRE can be shown using {typer}`dsh config show`:
 
-```{code} shell
+:::{code} shell
 $ dsh config show YOUR_SRE_NAME
-```
+:::
 
 - If you do not have a local copy, you can write one with the `--file` option:
 
-```{code} shell
+:::{code} shell
 $ dsh config show YOUR_SRE_NAME --file YOUR_SRE_NAME.yaml
-```
+:::
 
 - Edit the configuration file locally, and upload the new version using {typer}`dsh config upload`:
 
-```{code} shell
+:::{code} shell
 $ dsh config upload YOUR_SRE_NAME.yaml
-```
+:::
 
 - You will be shown the differences between the existing configuration and the new configuration and asked to confirm that they are correct.
 - Finally, deploy your SRE using {typer}`dsh sre deploy` to apply any changes:
 
-```{code} shell
+:::{code} shell
 $ dsh sre deploy YOUR_SRE_NAME
-```
+:::
 
 ::::{admonition} Changing administrator IP addresses
 :class: warning

--- a/docs/source/management/user.md
+++ b/docs/source/management/user.md
@@ -22,9 +22,9 @@ Grace;Hopper;+18005550100;grace@nasa.gov;US
 :::
 ::::
 
-```{code} shell
+:::{code} shell
 $ dsh users add PATH_TO_MY_CSV_FILE
-```
+:::
 
 ## List available users
 
@@ -34,9 +34,9 @@ $ dsh users add PATH_TO_MY_CSV_FILE
     1. Browse to **{menuselection}`Manage --> Members`** from the secondary menu on the left side
 - You can do this at the command line by running `dsh users list`:
 
-    ```{code} shell
+    :::{code} shell
     $ dsh users list YOUR_SRE_NAME
-    ```
+    :::
 
     which will give output like the following
 
@@ -56,9 +56,9 @@ $ dsh users add PATH_TO_MY_CSV_FILE
 1. You can do this directly in your Entra tenant by adding them to the **Data Safe Haven SRE _YOUR\_SRE\_NAME_ Users** group, following the instructions [here](https://learn.microsoft.com/en-us/entra/fundamentals/groups-view-azure-portal#add-a-group-member).
 1. Alternatively, you can add multiple users from the command line using {typer}`dsh users register`:
 
-    ```{code} shell
+    :::{code} shell
     $ dsh users register YOUR_SRE_NAME -u USERNAME_1 -u USERNAME_2
-    ```
+    :::
 
     where you must specify the usernames for each user you want to add to this SRE.
 

--- a/docs/source/overview/sensitivity_tiers.md
+++ b/docs/source/overview/sensitivity_tiers.md
@@ -16,12 +16,12 @@ When you set up your Data Safe Haven, you should think carefully about the secur
 The Data Safe Haven supports five sensitivity tiers out-of-the-box.
 A summary of the technical controls imposed at each tier by the Data Safe Haven codebase follows below.
 
-```{hint}
+:::{hint}
 The tiers used in the Data Safe Haven codebase are based on ideas from our [design choices](https://arxiv.org/abs/1908.08737) preprint.
 The preprint goes into further detail about the different tiers and outlines one possible classification scheme.
 
 Note that your organisation may classify projects differently and require different technical and non-technical controls.
-```
+:::
 
 (policy_tier_0)=
 
@@ -53,9 +53,9 @@ Non-technical restrictions related to information governance procedures may also
 
 Non-technical restrictions related to information governance procedures may also be applied according to your organisation's needs.
 
-```{admonition} Organisational networks
+:::{admonition} Organisational networks
 At the Turing connections to Tier 2 environments are only permitted from **Organisational** networks managed by the Turing or one of its organisational partners.
-```
+:::
 
 (policy_tier_3)=
 
@@ -67,18 +67,18 @@ At the Turing connections to Tier 2 environments are only permitted from **Organ
 
 Non-technical restrictions related to information governance procedures may also be applied according to your organisation's needs.
 
-```{admonition} Restricted networks
+:::{admonition} Restricted networks
 At the Turing connections to Tier 3 environments are only permitted from **Restricted** networks that are only accessible by known researchers.
-```
+:::
 
-```{admonition} Physical spaces
+:::{admonition} Physical spaces
 At the Turing connections to Tier 3 environments are only permitted from medium security spaces.
 Such spaces control the possibility of unauthorised viewing by requiring card access or other means of restricting entry to only known researchers (such as the signing in of guests on a known list) and screen adaptations or desk partitions are used in open-plan spaces if there is a high risk of unauthorised people viewing the user's screen.
-```
+:::
 
-```{admonition} Managed devices
+:::{admonition} Managed devices
 At the Turing connections to Tier 3 environments are also only permitted from managed devices (i.e. where the user is not an administrator) that have antivirus software installed and regular software updates applied.
-```
+:::
 
 (policy_tier_4)=
 
@@ -86,8 +86,8 @@ At the Turing connections to Tier 3 environments are also only permitted from ma
 
 The Data Safe Haven does not currently support environments suitable for the Tier 4 sensitivity level.
 
-```{caution}
+:::{caution}
 The Turing has not yet worked with any projects at the Tier 4 sensitivity level and so has only done some limited thinking on what controls would be appropriate for such projects.
 
 However, it is likely that such additional controls would at minimum include stronger restrictions on the physical spaces from which Tier 4 environments could be accessed.
-```
+:::

--- a/docs/source/overview/using_dsh.md
+++ b/docs/source/overview/using_dsh.md
@@ -5,19 +5,19 @@
 This page contains some important considerations you must take before using the Data Safe Haven.
 Where appropriate, there are links to external resources, including policies and processes used at The Turing.
 
-```{warning}
+:::{warning}
 Use of a Data Safe Haven is not by itself sufficient to guarantee the security of your data! It must be paired with appropriate information governance requirements and user agreements.
-```
+:::
 
-```{warning}
+:::{warning}
 Each organisation deploying their own instance of the Data Safe Haven is responsible for verifying their Data Safe Haven instance is deployed as expected and that the deployed configuration effectively supports their own information governance policies and processes.
 
 Each organisation deploying their own instance of the Data Safe Haven is responsible for verifying that the instance is configured as expected. The organisation is also reponsible for confirming that the deployed configuration is appropriate for their purposes and effectively supports their own information governance policies and processes. We provide the Data Safe Haven code and material on an ‘as is’ basis without warranties of any kind and you use the code and supporting materials at your own cost and risk.
-```
+:::
 
-```{tip}
+:::{tip}
 In terms of the [Five Safes framework](https://ukdataservice.ac.uk/help/secure-lab/what-is-the-five-safes-framework/) the Data Safe Haven is aiming to be a Safe Setting.
-```
+:::
 
 ## What is needed to run a Data Safe Haven?
 

--- a/docs/source/overview/using_dsh.md
+++ b/docs/source/overview/using_dsh.md
@@ -41,7 +41,7 @@ Every group deploying the Data Safe Haven will need to provide the rest includin
 
 The [Standard Architecture for Trusted Research Environments (SATRE)](https://satre-specification.readthedocs.io) project is a useful reference for TRE design.
 It features a comprehensive set of requirements, technical and non-technical, that a TRE operator should meet.
-An evaluation of the Data Safe Haven production instances at the Turing against SATRE can be found [here](https://satre-specification.readthedocs.io/en/stable/evaluations/alan_turing_institute.html).
+An evaluation of the Data Safe Haven production instances at the Turing against SATRE can be found [here](https://satre-specification.readthedocs.io/en/v1.1.1/evaluations/alan_turing_institute.html).
 
 ## Tiering
 

--- a/docs/source/overview/why_use_dsh.md
+++ b/docs/source/overview/why_use_dsh.md
@@ -50,6 +50,6 @@ We hope it will be useful in other contexts but you need to consider what altera
 We also hope that you will contribute any improvements back to the main project.
 You are responsible for verifying the Data Safe Haven is appropriate for your purposes and effectively supports your own information governance policies and processes.
 
-```{warning}
+:::{warning}
 The Data Safe Haven is not a managed service offered by the Alan Turing Institute. It is a set of instructions enabling you to set up your own secure environment.
-```
+:::

--- a/docs/source/roles/data_provider_representative/data_ingress.md
+++ b/docs/source/roles/data_provider_representative/data_ingress.md
@@ -11,14 +11,14 @@ Talk to your {ref}`role_system_manager` to discuss possible methods of bringing 
 It may be convenient to use [Azure Storage Explorer](https://azure.microsoft.com/en-us/products/storage/storage-explorer/).
 In this case you will not need log-in credentials, as your {ref}`role_system_manager` can provide a short-lived secure access token which will let you upload data.
 
-```{tip}
+:::{tip}
 You may want to keep the following considerations in mind when transferring data in order to reduce the chance of a data breach.
 
 - Use of short-lived access tokens limits the time within which an attacker can operate.
 - Letting your {ref}`role_system_manager` know a fixed IP address you will be connecting from (_e.g._ a corporate VPN) limits the places an attacker can operate from.
 - Communicating with your {ref}`role_system_manager` through a secure out-of-band channel (_e.g._ encrypted email) reduces the chances that an attacker can intercept or alter your messages in transit.
 
-```
+:::
 
 ## Preparing input data for the Data Safe Haven
 

--- a/docs/source/roles/investigator/data_egress.md
+++ b/docs/source/roles/investigator/data_egress.md
@@ -7,9 +7,9 @@ Once you have finished working with the data for your project, you'll have to co
 
 Once all parties have considered the sensitivity of outputs and agreed to release them, make sure that your {ref}`role_data_provider_representative` discusses the best way to extract your outputs from the environment with your {ref}`role_system_manager`.
 
-```{note}
+:::{note}
 You might want to define multiple data collections for egress, which would each have their own sensitivity.
 For example, you might separate a low-sensitivity written report from a high-sensitivity derived dataset.
 The egress process can then be adjusted based on the sensitivity of each dataset.
 For example, the low-sensitivity report can be publically released whereas the high-sensitivity derived dataset may go back to the data provider only.
-```
+:::

--- a/docs/source/roles/investigator/data_ingress.md
+++ b/docs/source/roles/investigator/data_ingress.md
@@ -5,9 +5,9 @@
 When working with sensitive data it is important to take utmost care with it.
 This will help you to ensure that the data integrity is maintained.
 
-```{attention}
+:::{attention}
 Ensure that you check what the expectations of your {ref}`role_data_provider_representative` are around data handling.
-```
+:::
 
 ## Classification
 

--- a/docs/source/roles/investigator/index.md
+++ b/docs/source/roles/investigator/index.md
@@ -13,9 +13,9 @@ As the research project lead, this individual is responsible for ensuring that p
 Multiple collaborating institutions may have their own lead staff members, and staff members might delegate responsibilities for the SRE to other researchers.
 However, each project must have a single lead **Investigator** who takes responsibility for it.
 
-```{warning}
+:::{warning}
 The **Investigator** must be able and willing to accept responsibility for the conduct of the project and its members.
-```
+:::
 
 [Data ingress](data_ingress.md)
 : What an **Investigator** needs to know about bringing data or software into the environment.

--- a/docs/source/roles/project_manager/data_egress.md
+++ b/docs/source/roles/project_manager/data_egress.md
@@ -4,12 +4,12 @@ Data Safe Havens are used for doing secure data research.
 Once the project is finished, it is important to extract all outputs from the environment before shutting it down.
 Each time you egress data from the environment, it must be checked to ensure that it is safe and appropriate to release.
 
-```{note}
+:::{note}
 You might want to define multiple data collections for egress, which would each have their own sensitivity.
 For example, you might separate a low-sensitivity written report from a high-sensitivity derived dataset.
 The egress process can then be adjusted based on the sensitivity of each dataset.
 For example, the low-sensitivity report can be publically released whereas the high-sensitivity derived dataset may go back to the data provider only.
-```
+:::
 
 ## Bringing data out of the environment
 
@@ -21,6 +21,6 @@ As for [data ingress](data_ingress.md), there are three methods of transferring 
 
 Ensure that the {ref}`role_data_provider_representative` and the {ref}`role_system_manager` discuss the most appropriate method to bring data out of the environment.
 
-```{danger}
+:::{danger}
 Under no circumstance should sensitive data be sent via email, even if encrypted.
-```
+:::

--- a/docs/source/roles/project_manager/data_ingress.md
+++ b/docs/source/roles/project_manager/data_ingress.md
@@ -13,9 +13,9 @@ There are three methods of transferring data to the Data Safe Haven (in order of
 
 Ensure that the {ref}`role_data_provider_representative` and the {ref}`role_system_manager` discuss the most appropriate method to bring data into the environment.
 
-```{danger}
+:::{danger}
 Under no circumstance should sensitive data be sent via email, even if encrypted.
-```
+:::
 
 ## Data ingress for a running project
 
@@ -23,8 +23,8 @@ If the project team need further data ingress after the project has started, ens
 They should reclassify the project.
 If the new security tier is higher than the one in which work has already started then the data ingress **is not permitted**.
 
-```{warning}
+:::{warning}
 If ingress of new data would change the classification of a project, we suggest determining the updated classification and deploying a new environment for it.
-```
+:::
 
 At the end of this process they should have classified the project into one of the Data Safe Haven security tiers.

--- a/docs/source/roles/project_manager/project_lifecycle.md
+++ b/docs/source/roles/project_manager/project_lifecycle.md
@@ -9,16 +9,16 @@ The first stage of any project involves identifying the different stakeholders.
 The {ref}`role_data_provider_representative` represents the organisation providing the data.
 Ensure that you have identified the **data owner** - the organisation who owns the dataset(s) being used.
 
-```{hint}
+:::{hint}
 Usually the **data provider** is also the **data owner**, but not in cases where they have purchased or loaned the data.
-```
+:::
 
 Ensure that the **data owner** has given this project permission to use the data.
 You can do this by checking with the **data controller** - an individual or group at the **data owner**.
 
-```{hint}
+:::{hint}
 There may be additional **data owner stakeholders** working at the **data owner** who can provide input to discussions around data sharing and data classification.
-```
+:::
 
 Next you should identify the {ref}`role_investigator` - the lead researcher with overall responsibility for the project.
 Finally, you should identify a referee, who will be able to provide an independent evaluation of the project's classification.

--- a/docs/source/roles/researcher/available_software.md
+++ b/docs/source/roles/researcher/available_software.md
@@ -11,30 +11,30 @@ The easiest way to update an SRD is by redeploying it - it may be possible for y
 
 ## Programming languages / compilers
 
-```{include} snippets/software_languages.partial.md
+:::{include} snippets/software_languages.partial.md
 :relative-images:
-```
+:::
 
 ## Editors / IDEs
 
-```{include} snippets/software_editors.partial.md
+:::{include} snippets/software_editors.partial.md
 :relative-images:
-```
+:::
 
 ## Writing / presentation tools
 
-```{include} snippets/software_presentation.partial.md
+:::{include} snippets/software_presentation.partial.md
 :relative-images:
-```
+:::
 
 ## Database access tools
 
-```{include} snippets/software_database.partial.md
+:::{include} snippets/software_database.partial.md
 :relative-images:
-```
+:::
 
 ## Other useful software
 
-```{include} snippets/software_other.partial.md
+:::{include} snippets/software_other.partial.md
 :relative-images:
-```
+:::


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

#2614 (it's not a hard dependency, it's just that I rebased this on top of it).

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

Mounting the datadrive with `noexec` prevents any scripts with the `exec` flag set from being executed directly from the drive. This impacts general usage and, in particular, prevents Python virtual environments from working correctly. This has a big impact on the utility of the datadrive for SRE users.

This change therefore removes the `noexec` flag from the datadrive mount so that scripts and virtual environments can be successfully used there.

It's worth noting that in my tests (see below) triggering a redeploy with this code caused the datadrive to be reprovisioned, which meant all of the data were wiped from it. Data on the home and shared mounts were unaffected.

I've rebased this PR on top of #2614 so that the CI pipeline can run without error. Consequently #2614 should be merged before this one is. 

#### Description of changes

The changes needed here are very minor. The `workspace.cloud_init.mustache.yaml` file is run to perform the cloud-init function on the workspace VM. This lists the mounts for the system:
```yaml
mounts:
  # Mount ephemeral storage at resource instead of default /mnt
  - [ephemeral0, /mnt/scratch]
  {{#data_disk_support}}
  # Mounting data disk
  - ["/dev/disk/azure/scsi1/lun0-part1", "/mnt/datadrive", auto, "defaults,noexec,nofail"]
  {{/data_disk_support}}
  # Desired state configuration is in a blob container mounted as NFSv3
  - ["{{storage_account_desired_state_name}}.blob.core.windows.net:/{{storage_account_desired_state_name}}
    /desiredstate", /var/local/ansible, nfs, "ro,_netdev,sec=sys,vers=3,nolock,proto=tcp"]
  [...]
```

The datadrive is mounted as `/mnt/datadrive` and as the diff shows, the `noexec` flag has been removed. For info about the format of this file see the [cloud-init mount](https://docs.cloud-init.io/en/latest/reference/modules.html#mounts) documentation and the [mount](https://man7.org/linux/man-pages/man8/mount.8.html) documentation.

As the [noexec section of the latter](https://man7.org/linux/man-pages/man8/mount.8.html#:~:text=Do%20not%20permit%20direct%20execution) explains, the `exec` flag is automatically included with `defaults` if there's no `noexec` flag, so removing `noexec` is sufficient to have the drive mounted as we want.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Contributes to #2602.
Contributes to https://github.com/alan-turing-institute/cvd-net/issues/117

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

I tested this out on a development SRE, see my [comments below.](https://github.com/alan-turing-institute/data-safe-haven/pull/2615#issuecomment-4916832679). The summary is that it did what was expected on an existing SRE. Running a deploy on the existing system caused the `cloud-init` script to be re-run and the datadrive to be remounted. All data on the datadrive were wiped as a result.

As far as I'm aware there aren't any existing unit tests for this. It'd be nice to have some, but I'd prefer them to be implemented as a separate task to avoid delaying integration of this change, which besides the datadrive being reprovisioned feels low-risk.