### PR TITLE
Updates to adjust to changes in the AzureSdk API

### DIFF
--- a/data_safe_haven/commands/shm.py
+++ b/data_safe_haven/commands/shm.py
@@ -121,7 +121,9 @@ def deploy(
         logger.critical(msg)
         raise typer.Exit(1) from exc
     # Upload config file to blob storage
+    logger.info("Uploading config files")
     config.upload(context)
+    logger.info(f"Successfully deployed SHM {fqdn}")
 
 
 @shm_command_group.command()

--- a/data_safe_haven/external/api/azure_sdk.py
+++ b/data_safe_haven/external/api/azure_sdk.py
@@ -101,9 +101,7 @@ class AzureSdk:
     @property
     def tenant_id(self) -> str:
         if not self.tenant_id_:
-            self.tenant_id_ = str(
-                self.get_subscription(self.subscription_name).tenant_id
-            )
+            self.tenant_id_ = str(self.credential().tenant_id)
         return self.tenant_id_
 
     def blob_client_(
@@ -434,7 +432,7 @@ class AzureSdk:
                                 tenant_id=tenant_id,
                                 object_id=admin_group_id,
                                 permissions=Permissions(
-                                    keys=[
+                                    keys_property=[
                                         "GET",
                                         "LIST",
                                         "CREATE",
@@ -508,6 +506,7 @@ class AzureSdk:
             )
             return key
         except AzureError as exc:
+            self.logger.error(f"Error: {exc}")
             msg = f"Failed to create key '{key_name}' in KeyVault '{key_vault_name}'."
             raise DataSafeHavenAzureError(msg) from exc
 

--- a/data_safe_haven/external/api/credentials.py
+++ b/data_safe_haven/external/api/credentials.py
@@ -46,12 +46,12 @@ class DeferredCredential(TokenCredential):
         self.skip_confirmation = skip_confirmation
         self.logger = get_logger()
         self.scopes = scopes
-        self.tenant_id = tenant_id
+        self.tenant_id_ = tenant_id
 
     @property
     def token(self) -> str:
         """Get a token from the credential provider."""
-        return str(self.get_token(*self.scopes, tenant_id=self.tenant_id).token)
+        return str(self.get_token(*self.scopes, tenant_id=self.tenant_id_).token)
 
     @classmethod
     def decode_token(cls, auth_token: str) -> dict[str, Any]:
@@ -125,6 +125,11 @@ class DeferredCredential(TokenCredential):
             )
         return DeferredCredential.tokens_[combined_scopes]
 
+    @property
+    def tenant_id(self) -> str | None:
+        """Return the tenant ID associated with the credential."""
+        return self.tenant_id_
+
 
 class AzureSdkCredential(DeferredCredential):
     """
@@ -165,7 +170,20 @@ class AzureSdkCredential(DeferredCredential):
             msg = "Selected credentials are incorrect."
             raise DataSafeHavenCachedCredentialError(msg)
 
+        self.tenant_id_ = decoded["tid"]
+
         return credential
+
+    @property
+    def tenant_id(self) -> str | None:
+        """
+        Return the tenant ID associated with the credential.
+
+        Overrides the DeferredCredential property of the same name.
+        """
+        if not self.tenant_id_:
+            self.get_credential()
+        return self.tenant_id_
 
 
 class GraphApiCredential(DeferredCredential):

--- a/data_safe_haven/external/api/graph_api.py
+++ b/data_safe_haven/external/api/graph_api.py
@@ -880,6 +880,7 @@ class GraphApi:
             json_response = self.http_get(f"{self.base_endpoint}/domains").json()
             return [dict(obj) for obj in json_response["value"]]
         except Exception as exc:
+            self.logger.error(f"Error: {exc}")
             msg = "Could not load list of domains."
             raise DataSafeHavenMicrosoftGraphError(msg) from exc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,7 +246,6 @@ def mock_azuresdk_get_subscription(
     subscription = Subscription()
     subscription.display_name = "Data Safe Haven Acme"
     subscription.subscription_id = request.config.guid_subscription
-    subscription.tenant_id = request.config.guid_tenant
     mocker.patch.object(
         AzureSdk,
         "get_subscription",
@@ -277,15 +276,25 @@ def mock_graphapi_get_credential(mocker: MockerFixture) -> None:
 
 
 @fixture
-def mock_azuresdk_get_credential(mocker: MockerFixture) -> None:
+def mock_azuresdk_get_credential(
+    mocker: MockerFixture, request: FixtureRequest
+) -> None:
     class MockCredential(TokenCredential):
         def get_token(*args, **kwargs) -> AccessToken:  # noqa: ARG002
             return AccessToken("dummy-token", 0)
+
+        @property
+        def tenant_id(self) -> str | None:
+            return request.config.guid_tenant
 
     mocker.patch.object(
         AzureSdkCredential,
         "get_credential",
         return_value=MockCredential(),
+    )
+
+    AzureSdkCredential.tenant_id = mocker.PropertyMock(
+        return_value=request.config.guid_tenant
     )
 
 

--- a/tests/external/api/test_azure_sdk.py
+++ b/tests/external/api/test_azure_sdk.py
@@ -255,7 +255,7 @@ class TestAzureSdk:
     def test_tenant_id(
         self,
         request,
-        mock_azuresdk_get_subscription,  # noqa: ARG002
+        mock_azuresdk_get_credential,  # noqa: ARG002
     ):
         sdk = AzureSdk("subscription name")
         assert sdk.tenant_id == request.config.guid_tenant


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

Nothing.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

After updating the AzureSdk various changes have been needed to align with changes to the API:

1. The Subscription object in our version of the AzureSdk doesn't expose a tenant_id member, so this is now read from the active user account instead. We are using 3.1.1 of the Subscription module. See the link below.

2. The Permissions class constructor "keys" parameter now takes the name "keys_property". We are on version 14.0.1 and this change was made in version 13.0.0. See the link below.

The Subscription module Changelog:
https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/subscription/azure-mgmt-subscription/CHANGELOG.md#320b1-2022-12-27

The KeyVault module Changelog:
https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md#1300-2025-12-11

### :mag: Detailed explanation of changes

Below is a file-by-file breakdown of the changes with explanations.

#### `data_safe_haven/commands/shm.py`

During testing I deployed an SHM and was a bit confused that there was no indication at the end that everything had been deployed successfully. I added a couple of new output lines which I though would be helpful for the user.

These changes aren't critical for this PR and can be removed if you feel they make things messy.

#### `data_safe_haven/external/api/azure_sdk.py`

The changes here and in `credentials.py` are the substantive changes of the PR. There are two things going on:

1. The `Permissions.keys` parameter is now called `Permissions.keys_property`. This change is detailed in the [Azure SDK ChangeLog](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-mgmt-keyvault/CHANGELOG.md#1300-2025-12-11) and has a simple fix: I just update the name.
2. The `Subscription` class no longer has a `tenant_id` property. This is [recorded in the AzureSdk ChangeLog](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/subscription/azure-mgmt-subscription/CHANGELOG.md#320b1-2022-12-27) has having been added in a version that we're not yet using, so practically speaking I'm not really sure why this has happened. Nevertheless, we can't use the `tenant_id` property with our version of the SDK. The change I've implemented to work around this is to get the tenant ID from the user's credential instead. This doesn't feel wrong to me, but you may feel differently.

#### `data_safe_haven/external/api/credentials.py`

We have our own `AzureSdkCredential` wrapper around the `TokenCredential` class from the AzureSdk, so some changes are needed here to expose the `tenant_id` property. The class hierarchy makes this a little tricky, but to ensure backwards compatibility I've turned the `tenant_id` member variable into a `property` which gets automatically populated in the background.

In the previous implementation `tenant_id` was never actually being populated. It now gets populated automatically when it's first queried.

I accept that the logic is a little convoluted here. My main aim was to ensure backwards compatibility, because although I don't think we were using the `tenant_id` member variable, I didn't want to risk making the assumption.

#### `data_safe_haven/external/api/graph_api.py`

I experienced some errors when using this method, added some debugging output and felt it might be helpful to keep it in. It's not critical for this PR, so I can remove it if you feel it's unhelpful.

#### `tests/external/api/test_azure_sdk.py`

Since the tenant ID is now being handled by the credentials rather than the subscription, the tenant Id test needs updating to use a different mock.

#### `tests/conftest.py`

There are two change here.

I've removed `tenant_id` from the `Subscription` mock so that it reflects the AzureSdk API.

I've also updated the `Credential` mock so that it handles the `tenant_id` property correctly.

The first change isn't necessary, but I think it makes sense. The second is necessary in order to get the tests to pass, but I think it's fair to say that it's not a cludge to get the tests through: it's a valid reflection of the AzureSdk API.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

This contributes to issue #2622 (Release 5.8.0).
PRs #2643, #2644 and #2624 build on these changes.

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Combined with the changes in Pull Requests #2643, #2644 and #2624 I've successfully performed several deployments of SREs at Tier 2 and Tier 3. With the combined changes the unit tests all pass.