### PR TITLE
Upgrade cvdupgrade to 1.2.0

### DIFF
--- a/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
+++ b/data_safe_haven/infrastructure/programs/sre/clamav_mirror.py
@@ -78,7 +78,7 @@ class SREClamAVMirrorComponent(ComponentResource):
             container_group_name=self.container_group_name,
             containers=[
                 containerinstance.ContainerArgs(
-                    image="chmey/clamav-mirror:latest",  # only one image is published
+                    image="ghcr.io/alan-turing-institute/clamav-mirror:5.8.0",
                     name="clamav-mirror"[:63],
                     environment_variables=[],
                     ports=[
@@ -111,14 +111,7 @@ class SREClamAVMirrorComponent(ComponentResource):
             dns_config=containerinstance.DnsConfigurationArgs(
                 name_servers=[props.dns_server_ip],
             ),
-            # Required due to DockerHub rate-limit: https://docs.docker.com/docker-hub/download-rate-limit/
-            image_registry_credentials=[
-                {
-                    "password": Output.secret(props.dockerhub_credentials.access_token),
-                    "server": props.dockerhub_credentials.server,
-                    "username": props.dockerhub_credentials.username,
-                }
-            ],
+            image_registry_credentials=[],
             ip_address=containerinstance.IpAddressArgs(
                 ports=[
                     containerinstance.PortArgs(


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

Depends on PRs #2642 and #2643 which should be merged first.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

The main change here is to upgrade cvdupgrade to version 1.2.0. The older version we were using no longer works on systems that are FIPS compliant, because it relies on MD5 checksums, which are no longer considered to be secure.

The source of the problem is that the clamav-mirror Docker image we use to run cvdupgrade is no longer being maintained and the cvdupdate version it contains has therefore been stuck on version 0.3.0 for several years.

This change therefore relies on a forked version of the Docker image that we'll need to maintain (it's very lightweight), but which now contains the updated version of the software we need.

See the forked image repository (and in particular the 5.8.0 releas) for more details:

https://github.com/alan-turing-institute/docker-clamav-mirror

### :mag: Detailed explanation of changes

Below is a file-by-file breakdown of the changes with explanations (there's actually only one file with changes here).

#### `data_safe_haven/infrastructure/programs/sre/clamav_mirror.py`

Up until now we've been using the [chmey/clamav-mirror](https://hub.docker.com/r/chmey/clamav-mirror) docker image as our ClamAV mirror. However, this has been archived by its owner and hasn't been updated for 5 years, which has been holding back the version of `cvpupgrade` our mirror was using.

This caused bug #2620. Thankfully the [source](https://github.com/chmey/docker-clamav-mirror) of the Docker image is available and is already set up to use the latest version of `cvpupgrade` whenever it's built, so all I've done is [made a Turing clone](https://github.com/alan-turing-institute/docker-clamav-mirror) of this.

The docker image is pushed to `ghcr.io` by the GitHub action, so in this file I point our image request at this new image repository.

I think it makes sense for us to start managing versions. This is really simple: we just trigger the GitHub action and a new docker image with the latest version of the OS and software will be generated. By tagging the images with the same version that we use for DSH we can ensure the two are always aligned. We don't have to generate a new image for each release, but this way we can do if we want to.

The other change is to remove the docker credentials from the request. Since the image is coming from `ghcr.io` rather than Docker Hub, these credentials are no longer needed here (they're still used elsewhere though).

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

Fixes #2620.
Contributes to #2622 (Release 5.8.0).
PR #2624 build on these changes.

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Combined with the changes in Pull Requests #2642, #2643 and #2624 I've successfully performed several deployments of SREs at Tier 2 and Tier 3. With the combined changes the unit tests all pass.