### PR TITLE
Bump version to 5.8.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ All organisations using an earlier version in production should update to the la
 
 | Version                                                                               | Supported          |
 | ------------------------------------------------------------------------------------- | ------------------ |
-| [5.7.1](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.7.1) | :white_check_mark: |
-| < 5.7.1                                                                               | :x:                |
+| [5.8.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.8.0) | :white_check_mark: |
+| < 5.8.0                                                                               | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -68,6 +68,10 @@ We usually deploy the latest available version of the Data Safe Haven for each o
 | September 2023   | DDRC DSG Exeter 2023          | [v4.1.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v4.1.0)           |
 | December 2023    | DSG 2023-12                   | [v4.1.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v4.1.0)           |
 | May 2024         | DSG 2024-05                   | [v4.2.1](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v4.2.1)           |
+| Sep 2024         | DSG 2024-09                   | [v5.0.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.0.0)           |
+| Jan 2025         | DSG 2025-01                   | [v5.2.1](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.2.1)           |
+| Sep 2025         | DSG 2025-09                   | [v5.5.1](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.5.1)           |
+| Jan 2026         | DSG 2026-01                   | [v5.7.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.7.0)           |
 
 Additionally, a production instance of DSH is maintained for use by research projects at the Turing.
 
@@ -88,6 +92,7 @@ Additionally, a production instance of DSH is maintained for use by research pro
 | 2025      | [v5.6.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.6.0)           |
 | 2026      | [v5.7.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.7.0)           |
 | 2026      | [v5.7.1](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.7.1)           |
+| 2026      | [v5.8.0](https://github.com/alan-turing-institute/data-safe-haven/releases/tag/v5.8.0)           |
 
 ## Versions that have undergone formal security evaluation
 

--- a/data_safe_haven/upgrade/upgrade.py
+++ b/data_safe_haven/upgrade/upgrade.py
@@ -76,13 +76,16 @@ class Upgrade:
                 self.logger.info(
                     f"You're using DSH version {self.dsh_version} but your SRE was deployed with version {self.sre_version}. Deployment will therefore trigger an upgrade."
                 )
-                if self.dsh_version >= Version("5.7.2"):
+                if (self.sre_version < Version("5.8.0")) and (
+                    self.dsh_version >= Version("5.8.0")
+                ):
                     self.logger.info(
-                        f"Upgrading to version {self.dsh_version} requires reprovisioning of several databases. All of the data on the following databases will therefore be lost during the upgrade:"
+                        f"Upgrading to version {self.dsh_version} requires reprovisioning of several components. All of the data on the following will be lost during the upgrade:"
                     )
-                    self.logger.info("1. Gitea")
-                    self.logger.info("2. Gitea mirror")
-                    self.logger.info("3. Hedgedoc")
+                    self.logger.info("1. Gitea database")
+                    self.logger.info("2. Gitea mirror database")
+                    self.logger.info("3. Hedgedoc database")
+                    self.logger.info("4. Workspace datadrives")
                     self.logger.info(
                         "If you have non-duplicate data stored on any of these you should back them up before proceeding."
                     )
@@ -105,14 +108,16 @@ class Upgrade:
         if self.fresh_deployment:
             changes = False
         elif self.dsh_version > self.sre_version:
-            if self.dsh_version >= Version("5.7.2"):
-                changes = self.upgrade_to_5_7_2()
+            if (self.sre_version < Version("5.8.0")) and (
+                self.dsh_version >= Version("5.8.0")
+            ):
+                changes = self.upgrade_to_5_8_0()
 
         return changes
 
-    def upgrade_to_5_7_2(self) -> bool:
-        """Upgrade from a version below 5.7.2 to a version at or above 5.7.2."""
-        self.logger.info("Preparing SRE for upgrade to version 5.7.2")
+    def upgrade_to_5_8_0(self) -> bool:
+        """Upgrade from a version below 5.8.0 to a version at or above 5.8.0."""
+        self.logger.info("Preparing SRE for upgrade to version 5.8.0")
 
         resource_group = self.project_manager.output("sre_resource_group")
         azure_sdk = AzureSdk(self.project_manager.context.subscription_name)

--- a/data_safe_haven/version.py
+++ b/data_safe_haven/version.py
@@ -1,2 +1,2 @@
-__version__ = "5.7.2"
+__version__ = "5.8.0"
 __version_info__ = tuple(__version__.split("."))

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -88,15 +88,14 @@ class TestUpgrade:
         capsys: CaptureFixture[str],
     ) -> None:
         """Check that patch version increments trigger an upgrade."""
-        with mock.patch.object(AzureSdk, "get_version", return_value="5.7.1"):
-            with mock.patch.object(version, "__version__", new="5.7.2"):
+        with mock.patch.object(AzureSdk, "get_version", return_value="5.8.0"):
+            with mock.patch.object(version, "__version__", new="5.8.1"):
                 upgrade = Upgrade(sre_project_manager)
                 proceed = upgrade.can_proceed()
                 assert not proceed
                 captured = capsys.readouterr()
-                assert "Gitea" in captured.out
-                assert "Gitea mirror" in captured.out
-                assert "Hedgedoc" in captured.out
+                assert "Deployment will therefore trigger an upgrade." in captured.out
+                assert "Gitea" not in captured.out
 
     def test_user_checks_minor_upgrade(
         self,
@@ -209,7 +208,7 @@ class TestUpgrade:
                 changes = upgrade.prepare()
                 assert not changes
 
-    def test_prepare_upgrade_5_7_2(
+    def test_prepare_upgrade_below_5_8_0(
         self,
         sre_project_manager: SREProjectManager,
         mock_sre_project_manager_output: None,  # noqa: ARG002
@@ -220,8 +219,29 @@ class TestUpgrade:
         """Check that an upgrade that requires no preparation also indicates that
         there are no changes to the stack.
         """
-        with mock.patch.object(AzureSdk, "get_version", return_value="5.7.1"):
-            with mock.patch.object(version, "__version__", new="5.7.2"):
+        with mock.patch.object(AzureSdk, "get_version", return_value="5.7.8"):
+            with mock.patch.object(version, "__version__", new="5.7.9"):
+                upgrade = Upgrade(sre_project_manager)
+                proceed = upgrade.can_proceed()
+                assert proceed
+                captured = capsys.readouterr()
+                assert "Deployment will therefore trigger an upgrade." in captured.out
+                changes = upgrade.prepare()
+                assert not changes
+
+    def test_prepare_upgrade_5_8_0(
+        self,
+        sre_project_manager: SREProjectManager,
+        mock_sre_project_manager_output: None,  # noqa: ARG002
+        mock_confirm_yes: None,  # noqa: ARG002
+        capsys: CaptureFixture[str],
+        mock_azuresdk_resource_manager_client: None,  # noqa: ARG002
+    ) -> None:
+        """Check that an upgrade that requires no preparation also indicates that
+        there are no changes to the stack.
+        """
+        with mock.patch.object(AzureSdk, "get_version", return_value="5.7.9"):
+            with mock.patch.object(version, "__version__", new="5.8.0"):
                 upgrade = Upgrade(sre_project_manager)
                 proceed = upgrade.can_proceed()
                 assert proceed
@@ -229,3 +249,24 @@ class TestUpgrade:
                 assert "Deployment will therefore trigger an upgrade." in captured.out
                 changes = upgrade.prepare()
                 assert changes
+
+    def test_prepare_upgrade_above_5_8_0(
+        self,
+        sre_project_manager: SREProjectManager,
+        mock_sre_project_manager_output: None,  # noqa: ARG002
+        mock_confirm_yes: None,  # noqa: ARG002
+        capsys: CaptureFixture[str],
+        mock_azuresdk_resource_manager_client: None,  # noqa: ARG002
+    ) -> None:
+        """Check that an upgrade that requires no preparation also indicates that
+        there are no changes to the stack.
+        """
+        with mock.patch.object(AzureSdk, "get_version", return_value="5.8.0"):
+            with mock.patch.object(version, "__version__", new="5.8.1"):
+                upgrade = Upgrade(sre_project_manager)
+                proceed = upgrade.can_proceed()
+                assert proceed
+                captured = capsys.readouterr()
+                assert "Deployment will therefore trigger an upgrade." in captured.out
+                changes = upgrade.prepare()
+                assert not changes


### PR DESCRIPTION
Preparations for DSH release v5.8.0.

## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

Depends on PRs #2642, #2643 and #2644 which should be merged first.


### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

This PR is for collecting together changes needed for release of version 5.8.0.

### :mag: Detailed explanation of changes

Below is a file-by-file breakdown of the changes with explanations.

#### `data_safe_haven/upgrade/upgrade.py`

There are a few minor changes here:
1. Some changes to the wording presented to the user during the upgrade for accuracy.
2. Previously I'd planned for this to be version 5.7.2, but at some point decided 5.8.0 was more appropriate. The numbers have been altered to address this.
3. There was a bug that meant the upgrade would be performed every time in the future, which is a mistake: it should only be performed if transitioning over the 5.8.0 boundary. The logic has been amended to fix this.

#### `data_safe_haven/version.py`

This bumps up the version number. There was never a 5.8.2 release; as I mentioned above, I'd originally planned for this to be 5.7.2 but since changed my mind.

#### `tests/upgrade/test_upgrade.py`

The tests needed updating to reflect changes following from the new version number. I also added to the tests to ensure the new logic (only upgrade if transitioning over the boundary) is adhered to.

#### `SECURITY.md`

Only the latest version is officially supported.

#### `VERSIONING.md`

Some info about previous DSGs was missing, so I've added it in.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

Combined with the changes in Pull Requests #2642, #2643 and #2644 I've successfully performed several deployments of SREs at Tier 2 and Tier 3. With the combined changes the unit tests all pass.

I ran through the security checklist for both Tier 2 and Tier 3 SREs. I had to apply the nexus fix to get them to pass, but having done so everything worked as expected. The results can be seen on the Release Issue #2622.