### PR TITLE
Handle config listing before first SRE deployment

### DIFF
--- a/data_safe_haven/commands/config.py
+++ b/data_safe_haven/commands/config.py
@@ -96,7 +96,9 @@ def available() -> None:
         raise typer.Exit(0)
 
     config_names = [blob.removeprefix("sre-").removesuffix(".yaml") for blob in blobs]
-    pulumi_config = DSHPulumiConfig.from_remote(context)
+    pulumi_config = DSHPulumiConfig.from_remote_or_create(
+        context, encrypted_key=None, projects={}
+    )
     deployed = pulumi_config.project_names
 
     headers = ["SRE Name", "Deployed"]

--- a/tests/commands/test_config_available_missing_pulumi.py
+++ b/tests/commands/test_config_available_missing_pulumi.py
@@ -1,0 +1,17 @@
+from data_safe_haven.commands.config import config_command_group
+from data_safe_haven.config import ContextManager, DSHPulumiConfig
+from data_safe_haven.external import AzureSdk
+
+
+def test_available_before_first_sre_deployment(context_manager, mocker, runner):
+    mocker.patch.object(ContextManager, "from_file", return_value=context_manager)
+    mocker.patch.object(AzureSdk, "list_blobs", return_value=["sre-sandbox.yaml"])
+    mocker.patch.object(DSHPulumiConfig, "remote_exists", return_value=False)
+    mock_download = mocker.patch.object(AzureSdk, "download_blob")
+
+    result = runner.invoke(config_command_group, ["available"])
+
+    assert result.exit_code == 0
+    assert "Available SRE configurations" in result.stdout
+    assert "sandbox" in result.stdout
+    mock_download.assert_not_called()


### PR DESCRIPTION
Fixes #2639.

## Summary
- treat a missing `pulumi.yaml` as an empty Pulumi project set when listing SRE configs
- keep uploaded SRE configurations visible before the first SRE deployment
- add regression coverage for the post-SHM/pre-SRE state

## Testing
- `ruff check` on changed files
- `black --check` on changed files
- focused regression test
- `mypy` on the changed production module