### PR TITLE
Document SHM Key Vault role requirement

### DIFF
--- a/docs/source/deployment/deploy_shm.md
+++ b/docs/source/deployment/deploy_shm.md
@@ -20,6 +20,7 @@ However, you may choose to use multiple SHMs if, for example, you want to separa
     - An account with [Global Administrator](https://learn.microsoft.com/en-us/entra/global-secure-access/reference-role-based-permissions#global-administrator) privileges on the tenant that you set up in the {ref}`configure_entra_id` step.
 - An Azure subscription where you will deploy your infrastructure
     - An account with at least [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/general#contributor) permissions on this subscription
+    - The same account must also have [Key Vault Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#key-vault-administrator) permissions at a scope covering the SHM Key Vault, so that deployment can create and access the Pulumi encryption key
 
 ## Deployment
 


### PR DESCRIPTION
Fixes #2638.

SHM deployment creates and accesses the Pulumi encryption key in Azure Key Vault. The deployment documentation currently lists Contributor permissions, but that role does not grant the required Key Vault data-plane actions.

Document the additional Key Vault Administrator requirement alongside the existing subscription Contributor requirement so deployment prerequisites match the permissions the CLI actually needs.