### PR TITLE
Document the SHM config display command

### DIFF
--- a/docs/source/deployment/deploy_shm.md
+++ b/docs/source/deployment/deploy_shm.md
@@ -70,6 +70,16 @@ You will be prompted to log in to the Azure CLI and to the Graph API.
 
 :::
 
+:::{hint}
+To inspect the configuration of an SHM that has already been deployed for the selected context, run:
+
+:::{code} shell
+$ dsh config show-shm
+:::
+
+This is useful when validating an existing SHM or preparing to update or redeploy it. Pass `--file PATH` to write the configuration to a file instead of printing it to the console.
+:::
+
 :::{important}
 You may be asked to delegate your domain name to Azure. To do this, you'll need to know details about the parent domain. For example, if you are deploying to `dsh.example.com` then the parent name is `example.com`.
 


### PR DESCRIPTION
## Summary

Document the existing `dsh config show-shm` command in the SHM deployment guide.

The command allows administrators to inspect the configuration of the SHM associated with the currently selected context, which is useful when validating, updating, or redeploying an existing environment.

The documentation also notes that the configuration can be written to a file with the `--file` option.

## Related issues

Fixes #2268.

## Tests

Documentation only.