### PR TITLE
Document self-code ingress with Gitea mirrors

### DIFF
--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -7,6 +7,7 @@ setup_context.md
 configure_entra_id.md
 deploy_shm.md
 deploy_sre.md
+self_code_ingress.md
 security_checklist.md
 :::
 
@@ -16,6 +17,7 @@ Deploying an instance of the Data Safe Haven involves the following steps:
 - Configuring the Microsoft Entra directory where you will manage users
 - Deploying the Safe Haven management component
 - Deploying a Secure Research Environment for each project
+- Optionally [configuring pre-approved GitHub repositories for code ingress](self_code_ingress.md)
 
 ## Requirements
 

--- a/docs/source/deployment/self_code_ingress.md
+++ b/docs/source/deployment/self_code_ingress.md
@@ -2,10 +2,10 @@
 
 # Ingress pre-approved code repositories
 
-For Tier 2 and Tier 3 SREs, administrators can make selected GitHub repositories available inside the environment without enabling general workspace internet access.
+For SREs where workspace internet access is disabled, administrators can make selected GitHub repositories available inside the environment without enabling general internet access.
 Data Safe Haven mirrors the configured repositories into the internal Gitea service, where researchers can access them through the `workspaceuser` account.
 
-The mirror service is not deployed for Tier 0 and Tier 1 SREs, which already have direct internet access.
+The mirror service is deployed only when workspace internet access is disabled and at least one repository is configured.
 
 ## Configure repositories
 

--- a/docs/source/deployment/self_code_ingress.md
+++ b/docs/source/deployment/self_code_ingress.md
@@ -1,0 +1,31 @@
+(self_code_ingress)=
+
+# Ingress pre-approved code repositories
+
+For Tier 2 and Tier 3 SREs, administrators can make selected GitHub repositories available inside the environment without enabling general workspace internet access.
+Data Safe Haven mirrors the configured repositories into the internal Gitea service, where researchers can access them through the `workspaceuser` account.
+
+The mirror service is not deployed for Tier 0 and Tier 1 SREs, which already have direct internet access.
+
+## Configure repositories
+
+Add repositories under `user_services.gitea_mirror.repositories` in the SRE configuration file:
+
+:::{code} yaml
+user_services:
+  gitea_mirror:
+    repositories:
+      - repository_name: data-safe-haven
+        repository_url: https://github.com/alan-turing-institute/data-safe-haven
+        repository_auth_token: YOUR_READ_ONLY_GITHUB_TOKEN
+:::
+
+Each repository entry requires:
+
+- `repository_name`: the name used to identify the repository in the mirror service.
+- `repository_url`: the GitHub repository URL.
+- `repository_auth_token`: a read-only GitHub personal access token with access to the repository.
+
+Use a token with only the permissions required to read the repository. If no repositories should be mirrored, leave `repositories` empty.
+
+After the SRE is deployed, the configured repositories are available from the internal Gitea service and are refreshed automatically by the mirror manager.


### PR DESCRIPTION
## Summary

Document the pre-approved code ingress functionality provided by the Gitea repository mirror.

The new documentation explains how administrators can configure GitHub repositories under `user_services.gitea_mirror.repositories`, including:

- `repository_name`
- `repository_url`
- `repository_auth_token`

It also explains that the token should have only the permissions required to read the repository, that configured repositories are exposed through the internal Gitea service, and that the mirror manager refreshes them automatically.

The documentation reflects the current implementation, where the mirror infrastructure is created when workspace internet access is disabled and at least one repository is configured.

## Related issues

Fixes #2501.

## Tests

Documentation only.