### PR TITLE
Document the v5 workspace smoke tests

### DIFF
--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -7,6 +7,7 @@ setup_context.md
 configure_entra_id.md
 deploy_shm.md
 deploy_sre.md
+smoke_tests.md
 security_checklist.md
 :::
 
@@ -16,6 +17,7 @@ Deploying an instance of the Data Safe Haven involves the following steps:
 - Configuring the Microsoft Entra directory where you will manage users
 - Deploying the Safe Haven management component
 - Deploying a Secure Research Environment for each project
+- Optionally [validating a deployed workspace with the smoke tests](smoke_tests.md)
 
 ## Requirements
 

--- a/docs/source/deployment/smoke_tests.md
+++ b/docs/source/deployment/smoke_tests.md
@@ -1,0 +1,15 @@
+(workspace_smoke_tests)=
+
+# Run workspace smoke tests
+
+After deploying an SRE, you can run the installed smoke-test suite from a workspace to check that the environment is functioning correctly.
+
+The tests are installed in `/usr/local/smoke_tests` and should be run as root from that directory. Running them from the smoke-test directory is required because the suite invokes several companion scripts using relative paths.
+
+:::{code} shell
+$ sudo -i
+# cd /usr/local/smoke_tests
+# ./run_all_tests.bats
+:::
+
+The suite checks workspace mounts, Python and R package repositories and functionality, and database connectivity when database credentials are available.


### PR DESCRIPTION
## Summary

Update the deployment documentation with the current location and invocation of the Data Safe Haven workspace smoke tests.

The smoke-test suite is installed at:

`/usr/local/smoke_tests`

The documentation now explains that administrators should switch to root, change into that directory, and run:

`./run_all_tests.bats`

This replaces the outdated documentation referenced in #2337 and matches the location used by the current Ansible deployment.

## Related issues

Fixes #2337.

## Tests

Documentation only.