### PR TITLE
Name SRE in teardown confirmation

### DIFF
--- a/data_safe_haven/commands/sre.py
+++ b/data_safe_haven/commands/sre.py
@@ -235,7 +235,7 @@ def teardown(
             "Ensure that any desired outputs have been extracted before continuing."
         )
         if not console.confirm(
-            "Do you wish to continue tearing down the SRE?", default_to_yes=False
+            f"Do you wish to continue tearing down SRE '{name}'?", default_to_yes=False
         ):
             console.print("SRE teardown cancelled by user.")
             raise typer.Exit(0)

--- a/tests/commands/test_sre.py
+++ b/tests/commands/test_sre.py
@@ -152,4 +152,5 @@ class TestTeardownSRE:
     ) -> None:
         result = runner.invoke(sre_command_group, ["teardown", "sandbox"], input="n")
         assert result.exit_code == 0
+        assert "Do you wish to continue tearing down SRE 'sandbox'?" in result.stdout
         assert "cancelled by user" in result.stdout


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] Meaningful title
- [x] Targets `develop`
- [x] Branch is based on the current target branch

### :vertical_traffic_light: Depends on

None.

### :arrow_heading_up: Summary

Include the SRE name in the destructive teardown confirmation so users can verify the exact environment before proceeding.

- update the confirmation prompt to include the SRE name
- add regression coverage for the prompt

### :closed_umbrella: Related issues

Closes #2406

### :microscope: Tests

Updated `tests/commands/test_sre.py` to verify the SRE name appears in the confirmation prompt.