### PR TITLE
Clarify Tier 3 physical security checks

### DIFF
--- a/docs/source/deployment/security_checklist.md
+++ b/docs/source/deployment/security_checklist.md
@@ -273,7 +273,7 @@ There are network rules permitting access to the portal from allowed IP addresse
 - Medium security research spaces control the possibility of unauthorised viewing.
 - Card access or other means of restricting entry to only known researchers (such as the signing in of guests on a known list) is required.
 - Screen adaptations or desk partitions can be adopted in open-plan spaces if there is a high risk of "visual eavesdropping".
-- Firewall rules can permit access only from IP ranges corresponding to these research spaces.
+- Network security group rules can permit access only from IP ranges corresponding to these research spaces.
 
 ### Implication:
 
@@ -282,8 +282,6 @@ There are network rules permitting access to the portal from allowed IP addresse
 ### Verify by:
 
 #### Physical security ({ref}`policy_tier_3`)
-
-Connection from outside the secure physical space is not possible.
 
 - Attempt to connect to the {ref}`policy_tier_3` SRE web client from home using a managed device and the correct VPN connection and credentials.
 
@@ -300,7 +298,7 @@ Connection from within the secure physical space is possible.
 :::
 
 :::{attention}
-{{white_check_mark}} Verify that: check the network IP ranges corresponding to the research spaces and compare against the IPs accepted by the firewall.
+{{white_check_mark}} Verify that: the network IP ranges corresponding to the research spaces match the source IP ranges allowed by the Guacamole application gateway NSG.
 :::
 
 :::{attention}

--- a/docs/source/deployment/security_checklist/security_checklist_template.md
+++ b/docs/source/deployment/security_checklist/security_checklist_template.md
@@ -74,7 +74,7 @@ Running on SHM/SREs deployed using commit xxxxxx
     - :white_check_mark:/:partly_sunny:/:fast_forward:/:x: <b>Verify that</b>: connection fails.
 - Attempt to connect from research office using a managed device and the correct VPN connection and credentials.
     - :white_check_mark:/:partly_sunny:/:fast_forward:/:x: <b>Verify that</b>: connection succeeds
-    - :white_check_mark:/:partly_sunny:/:fast_forward:/:x: <b>Verify that</b>: the network IP ranges corresponding to the research spaces correspond to those allowed by storage account firewall
+    - :white_check_mark:/:partly_sunny:/:fast_forward:/:x: <b>Verify that</b>: the network IP ranges corresponding to the research spaces match the source IP ranges allowed by the Guacamole application gateway NSG
     - :white_check_mark:/:partly_sunny:/:fast_forward:/:x: <b>Verify that</b>: physical measures such as screen adaptions or desk partitions are present if risk of visual eavesdropping is high
 
 ### Remote connections


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] Meaningful title
- [x] Targets `develop`
- [x] Branch is based on the current target branch

### :arrow_heading_up: Summary

Clarify the Tier 3 physical-security checks so the documentation matches the controls described elsewhere in the checklist.

- remove the absolute statement that connection from outside the secure physical space is impossible
- identify the application gateway NSG, rather than the firewall, as the control whose allowed source IP ranges should be checked
- update the downloadable security-checklist template to match the published guide

### :closed_umbrella: Related issues

Closes #2285.

### :microscope: Tests

Documentation only.