### PR TITLE
Pass api_version as named rather than positional argument

### DIFF
--- a/data_safe_haven/external/api/azure_sdk.py
+++ b/data_safe_haven/external/api/azure_sdk.py
@@ -583,7 +583,9 @@ class AzureSdk:
             self.credential(), self.subscription_id
         ) as resource_client:
             azure_id = f"/subscriptions/{self.subscription_id}/resourceGroups/{resource_group_name}/providers/{provider_namespace}/{resource_type}/{resource_name}"
-            resource = resource_client.resources.get_by_id(azure_id, "2026-01-01")
+            resource = resource_client.resources.get_by_id(
+                azure_id, api_version="2026-01-01"
+            )
 
         return resource
 
@@ -631,7 +633,7 @@ class AzureSdk:
             # ServerIsBusy exceptions, so we must delete the resources sequentially
             for completed, resource_id in enumerate(resource_ids):
                 poller = resource_client.resources.begin_delete_by_id(
-                    resource_id, "2026-01-01"
+                    resource_id, api_version="2026-01-01"
                 )
                 spinners = ["    ", ".   ", "..  ", "... ", "...."]
                 done = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -715,7 +715,9 @@ def mock_sre_project_manager_output(mocker: MockerFixture) -> None:
 
 @fixture
 def mock_azuresdk_resource_manager_client(mocker: MockerFixture) -> None:
-    def side_effect_get_by_id(azure_id: str, _sdk_version: str) -> GenericResource:
+    def side_effect_get_by_id(
+        azure_id: str, *, api_version: str  # noqa: ARG001
+    ) -> GenericResource:
         resource = GenericResource()
         resource.id = azure_id
         return resource
@@ -730,8 +732,8 @@ def mock_azuresdk_resource_manager_client(mocker: MockerFixture) -> None:
         def done(self) -> bool:
             return self.duration <= 0
 
-    def side_effect_begin_delete_by_id(azure_id: str, sdk_version: str) -> Poller:
-        return Poller(azure_id + sdk_version)
+    def side_effect_begin_delete_by_id(azure_id: str, *, api_version: str) -> Poller:
+        return Poller(azure_id + api_version)
 
     mocker.patch.object(
         ResourcesOperations, "get_by_id", side_effect=side_effect_get_by_id


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Thank you for your pull request!

- Before going any further, please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- If you're not yet ready to merge, please mark this pull request as a **draft** and add `'[WIP]'` to the title
- Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] You have given your pull request a meaningful title (_e.g._ `Enable foobar integration` rather than `515 foobar`).
- [x] You are targeting the appropriate branch. If you're not certain which one this is, it should be **`develop`**.
- [x] Your branch is up-to-date with the **target branch** (it probably was when you started, but it may have changed since then).

### :vertical_traffic_light: Depends on

<!--
List any other PRs that must be merged before this one
-->

No dependencies.

However, this should be part of the 5.8.0 release, so I'd be inclined to re-write the history of `develop` so that this commit ends up earlier than the "Bump version to 5.8.0" commit 3aa09bdfed09fe. I'd be interested in opinions on this.

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
You might (optionally) want to include screenshots here.
-->

The Python AzureSdk API changed in version 26.0.0 so that various ResourcesOperations calls change the api_version argument from being positional or keyword to keyword only.

Since we were calling ResourcesOperations.get_id() and ResourcesOperations.begin_delete_by_id() with it as a positional argument, this has needed to be changed now that we're using 26.0.0 so it's passed as a named argument instead.

See the [ResourceOperations API is documented](https://learn.microsoft.com/en-us/python/api/azure-mgmt-resource/azure.mgmt.resource.resources.operations.resourcesoperations?view=azure-python) for info about the specific calls and their current interface.

See the following from the azure-mgmt-resource_26.0.0 ChangeLog:

> Method ResourcesOperations.begin_create_or_update/
> begin_create_or_update_by_id/ begin_delete/begin_delete_by_id/ begin_update/
> begin_update_by_id/ check_existence/ check_existence_by_id/ get/ get_by_id
> changed its parameter api_version from positional_or_keyword to keyword_only

https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-mgmt-resource_26.0.0

## Detailed notes

File-by-file breakdown of changes.

### `data_safe_haven/external/api/azure_sdk.py`

This is the material change. The calls to `get_by_id()` and `begin_delete_by_id()` have been amended so that the `api-version` argument is passed as a named argument.

The only other changes here involve reformatting to appease the linter.

### `tests/conftest.py`

The mock resource manager client also has to be updated to accept `api_version` as a named argument. The change here both adds it as a possibility and makes it a requirement.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues (hopefully it will!) then add `Closes #<issue number>` here.
-->

### :microscope: Tests

<!--
- Document any manual tests that you have carried out (*e.g.* deploying a new SHM and/or SRE) and confirm which commit you did this with
- Note that automated tests will be run as part of the CI process and will block this PR until they pass.
- Additionally, a successful code review may be required before this PR can be merged.
- If this pull request only changed documentation you can simply state 'Documentation only' here.
-->

The issue was triggered during an upgrade from 5.7.1 to 5.8.0. After making the change I've performed a full upgrade which passed successfully.